### PR TITLE
Update mimemagic in Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/projectblacklight/blacklight_oai_provider.git
-  revision: 76b6a2ae6fc0068aa93a3035051fb333c4564795
+  revision: 453e91d4df49414c2d01432413b4441dc1e2bcda
   specs:
     blacklight_oai_provider (7.0.0)
       blacklight (~> 7.0)
@@ -243,7 +243,7 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2021.0225)
-    mimemagic (0.3.5)
+    mimemagic (0.3.6)
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.4)
@@ -257,7 +257,7 @@ GEM
       net-ssh (>= 2.6.5, < 7.0.0)
     net-ssh (6.1.0)
     nio4r (2.5.7)
-    nokogiri (1.11.1)
+    nokogiri (1.11.2)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
     ntlm-http (0.1.1)
@@ -338,7 +338,7 @@ GEM
     rspec-mocks (3.10.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
-    rspec-rails (5.0.0)
+    rspec-rails (5.0.1)
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       railties (>= 5.2)


### PR DESCRIPTION
[Dependency on mimemagic 0.3.x no longer valid](https://github.com/rails/rails/issues/41750)

Ran bundle update to update the version of mimemagic in the Gemfile.lock