### PR TITLE
APPS-653: Update default sort to shelfmark for facet only search

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -61,8 +61,8 @@ class ApplicationController < ActionController::Base
   end
 
   def set_default_sort
-    # set sort to be relevance if search is not empty
-    params[:sort] ||= 'score desc' if !params[:q].to_s.empty? || !params[:f].to_s.empty?
+    # set sort to be relevance if keyword search is not empty
+    params[:sort] ||= 'score desc' if !params[:q].to_s.empty?
   end
 
   def sinai_authenticated?

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -62,7 +62,7 @@ class ApplicationController < ActionController::Base
 
   def set_default_sort
     # set sort to be relevance if keyword search is not empty
-    params[:sort] ||= 'score desc' if !params[:q].to_s.empty?
+    params[:sort] ||= 'score desc' unless params[:q].to_s.empty?
   end
 
   def sinai_authenticated?


### PR DESCRIPTION
Acceptance Criteria:

- [x] Empty search defaults to Shelfmark A-Z
- [x] Facet only search defaults to Shelfmark A-Z
- [x] Keyword only search defaults to Relevance
- [x] Keyword and facet search defaults to relevance