### PR TITLE
APPS-697: fixes bugs causing errors when certain fields are empty

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -473,7 +473,7 @@ class CatalogController < ApplicationController
       format.json
       additional_export_formats(@document, format)
     end
-    if @document[:has_model_ssim][0] == 'Collection'
+    if @document[:has_model_ssim].to_a[0] == 'Collection'
       facet_member_of_collections = blacklight_config.facet_fields['member_of_collections_ssim']
       if facet_member_of_collections
         @response_collection = search_service.facet_field_response(facet_member_of_collections.key, "f.member_of_collections_ssim.facet.contains" => @document[:title_tesim][0])

--- a/app/views/catalog/show.html.erb
+++ b/app/views/catalog/show.html.erb
@@ -1,4 +1,4 @@
-<% if @document[:has_model_ssim][0] == 'Collection' %>
+<% if @document[:has_model_ssim].to_a[0] == 'Collection' %>
 <%
 @page_title = if Flipflop.sinai?
                 t('blacklight.search.show.title', document_title: document_show_html_title, application_name: sinai_application_name).html_safe

--- a/app/views/catalog/work_record--sinai/_references_and_link_metadata.html.erb
+++ b/app/views/catalog/work_record--sinai/_references_and_link_metadata.html.erb
@@ -1,7 +1,7 @@
 <% doc_presenter = show_presenter(document) %>
 <% references = Sinai::ReferencesMetadataPresenter.new(document: doc_presenter.fields_to_render).references_terms %>
 
-<% if (references.length > 0) || (@document[:other_versions_tesim].length > 0) %>
+<% if (references.length > 0) || (@document[:other_versions_tesim].to_a.length > 0) %>
 
   <input type="radio" name="tabs" id="tabfive">
   <label for="tabfive">References</label>
@@ -22,7 +22,7 @@
     <% end %>
 
     <%# other_versions_tesim %>
-    <% if @document[:other_versions_tesim] %>
+    <% if @document[:other_versions_tesim].to_a.length > 0 %>
       <div class="metadata-block--sinai">
         <span class="metadata-block_title--sinai">
           <%= 'Other version(s)' %>

--- a/app/views/catalog/work_record--ursus/_access_condition_metadata.html.erb
+++ b/app/views/catalog/work_record--ursus/_access_condition_metadata.html.erb
@@ -1,7 +1,7 @@
 <% doc_presenter = show_presenter(document) %>
 <% access_condition = Ursus::AccessConditionMetadataPresenter.new(document: doc_presenter.fields_to_render).access_condition_terms %>
 
-<% if access_condition.length > 0 %>
+<% if access_condition.to_a.length > 0 %>
   <div class='metadata-block'>
     <h4 class='metadata-block__title'>Access Condition</h4>
     <dl class='metadata-block__group'>
@@ -24,11 +24,7 @@
       <%= render 'license' %>
     </dl>
 
-  <% if Flipflop.sinai? %>
     <hr class='divider'>
-  <% else %>
-    <hr class='divider divider--white'>
-  <% end %>
 
   </div>
 <% end %>

--- a/app/views/catalog/work_record--ursus/_find_this_item_metadata.html.erb
+++ b/app/views/catalog/work_record--ursus/_find_this_item_metadata.html.erb
@@ -22,19 +22,7 @@
         </dt>
       <% end %>
       <%= render_opac_link %>
-
-      <!-- iiif drag and drop logo -->
-      <% if !Flipflop.sinai? %>
-        <dt class='metadata-block__label-key'>Manifest url</dt>
-        <dd class='metadata-block__label-value'>
-          <a href="<%= @document[:iiif_manifest_url_ssi] %>" target="_blank"><%= image_tag('iiif-logo.png', alt: 'IIIF Manifest') %></a>
-        </dd>
-      <% end %>
-
-      <!-- other versions -->
-      <% if Flipflop.sinai? %>
-        <%= render 'otherversion' %>
-      <% end %>
+      <%= render 'otherversion' %>
     </dl>
     <hr>
     <% if Flipflop.sinai? %>

--- a/app/views/catalog/work_record--ursus/_note_metadata.html.erb
+++ b/app/views/catalog/work_record--ursus/_note_metadata.html.erb
@@ -35,11 +35,7 @@
       <dd class='metadata-block__label-value'><%= raw toc_value %></dd>
     </dl>
 
-  <% if Flipflop.sinai? %>
    <hr class='divider'>
-  <% else %>
-    <hr class='divider divider--ursus'>
-  <% end %>
 
   </div>
 <% end %>

--- a/app/views/catalog/work_record--ursus/_physical_description_metadata.html.erb
+++ b/app/views/catalog/work_record--ursus/_physical_description_metadata.html.erb
@@ -22,12 +22,6 @@
         </dt>
       <% end %>
     </dl>
-
-  <% if Flipflop.sinai? %>
-   <hr class='divider'>
-  <% else %>
-    <hr class='divider divider--ursus'>
-  <% end %>
-
+    <hr class='divider'>
   </div>
 <% end %>

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -119,18 +119,25 @@ RSpec.describe CatalogController, type: :controller do
     end
   end
 
-  xdescribe "show action" do
-    before do
-      # allow(controller).to receive(:search_service).and_return(search_service)
-      # expect(search_service).to receive(:fetch).and_return([mock_response, mock_document])
-    end
-    # let(:doc_id) { '2007020969' }
-    # let(:mock_response) { instance_double(Blacklight::Solr::Response) }
-    # let(:mock_document) { instance_double(SolrDocument, export_formats: {}) }
-    # let(:search_service) { instance_double(Blacklight::SearchService) }
+  describe "show action" do
+    render_views
 
-    it "has collection count on Collection Item record page" do
-      # get :show, params: { id: doc_id }
+    before do
+      allow(controller).to receive(:enforce_show_permissions).and_return(true)
+      allow(controller).to receive(:search_service).and_return(search_service)
+      allow(search_service).to receive(:fetch).and_return([mock_response, mock_document])
+    end
+    let(:ark) { 'ark:/123/abc' }
+    let(:mock_response) { instance_double(Blacklight::Solr::Response) }
+    let(:mock_document) { SolrDocument.new(id: ark, export_formats: {}) }
+    let(:search_service) { instance_double(Blacklight::SearchService) }
+
+    it 'Renders a blank SolrDocument (meaning missing fields don\'t cause errors)' do
+      get :show, params: { id: ark }
+    end
+
+    xit "has collection count on Collection Item record page" do
+      # get :show, params: { id: ark }
       # expect(assigns[:document]).not_to be_nil
     end
   end


### PR DESCRIPTION
If a SolrDocument field is empty, then document[:field] will return `nil`. This typically causes errors when using array methods on the result, for example `if document[:field].length > 0`. They can be fixed by calling `document[:field].to_a`, which will transform `nil` to `[]`, but leave arrays as is.

- fixes the error cited in APPS-697, raised at app/views/catalog/work_record--sinai/_references_and_link_metadata.html.erb:4
- tests that a blank solr document (with every possible field empty) will render
- fixes similar bugs revealed by the new test
- removes non-sinai code found incidentally while inspecting templates.