### PR TITLE
Apps-815 - Timeout sinai ID logins after three days

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This section gives basic instructions to get Ursus running locally. More extensi
 
 ### Install and run locally
 
-Ursus is a Black application and only needs Solr and Fedora.
+Ursus is a [Blacklight](https://projectblacklight.org/) application and only needs Solr and Fedora.
 
 Ursus can be locally run in two ways:
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -84,7 +84,7 @@ class ApplicationController < ActionController::Base
 
   def set_auth_cookies
     cookies[:sinai_authenticated_3day] = {
-      value: ENV['DOMAIN'],
+      value: create_encrypted_string.unpack('H*')[0].upcase,
       expires: Time.zone.now + 60,
       domain: ENV['DOMAIN']
     }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -84,7 +84,7 @@ class ApplicationController < ActionController::Base
 
   def set_auth_cookies
     cookies[:sinai_authenticated_3day] = {
-      value: create_encrypted_string.unpack('H*')[0].upcase,
+      value: ENV['DOMAIN'],
       expires: Time.zone.now + 60,
       domain: ENV['DOMAIN']
     }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -90,7 +90,7 @@ class ApplicationController < ActionController::Base
     }
     cookies[:initialization_vector] = {
       value: cipher_iv.unpack('H*')[0].upcase,
-      expires: Time.zone.now +3.days,
+      expires: Time.zone.now + 3.days,
       domain: ENV['DOMAIN']
     }
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -85,12 +85,12 @@ class ApplicationController < ActionController::Base
   def set_auth_cookies
     cookies[:sinai_authenticated_3day] = {
       value: create_encrypted_string.unpack('H*')[0].upcase,
-      expires: Time.zone.now + 25.years,
+      expires: Time.zone.now + 60,
       domain: ENV['DOMAIN']
     }
     cookies[:initialization_vector] = {
       value: cipher_iv.unpack('H*')[0].upcase,
-      expires: Time.zone.now + 25.years,
+      expires: Time.zone.now + 60,
       domain: ENV['DOMAIN']
     }
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -84,7 +84,7 @@ class ApplicationController < ActionController::Base
 
   def set_auth_cookies
     cookies[:sinai_authenticated_3day] = {
-      value: ENV['CIPHER_KEY'],
+      value: create_encrypted_string.unpack('H*')[0].upcase,
       expires: Time.zone.now + 25.years,
       domain: ENV['DOMAIN']
     }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -85,12 +85,12 @@ class ApplicationController < ActionController::Base
   def set_auth_cookies
     cookies[:sinai_authenticated] = {
       value: create_encrypted_string.unpack('H*')[0].upcase,
-      expires: Time.zone.now + 60,
+      expires: Time.zone.now + 2.years,
       domain: ENV['DOMAIN']
     }
     cookies[:initialization_vector] = {
       value: cipher_iv.unpack('H*')[0].upcase,
-      expires: Time.zone.now + 60,
+      expires: Time.zone.now + 2.years,
       domain: ENV['DOMAIN']
     }
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -85,12 +85,12 @@ class ApplicationController < ActionController::Base
   def set_auth_cookies
     cookies[:sinai_authenticated] = {
       value: create_encrypted_string.unpack('H*')[0].upcase,
-      expires: Time.zone.now + 1.mins,
+      expires: Time.zone.now + 25.years,
       domain: ENV['DOMAIN']
     }
     cookies[:initialization_vector] = {
       value: cipher_iv.unpack('H*')[0].upcase,
-      expires: Time.zone.now + 1.mins,
+      expires: Time.zone.now + 25.years,
       domain: ENV['DOMAIN']
     }
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -84,7 +84,7 @@ class ApplicationController < ActionController::Base
 
   def set_auth_cookies
     cookies[:sinai_authenticated_3day] = {
-      value: create_encrypted_string.unpack('H*')[0].upcase,
+      value: ENV['CIPHER_KEY'],
       expires: Time.zone.now + 25.years,
       domain: ENV['DOMAIN']
     }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -85,12 +85,12 @@ class ApplicationController < ActionController::Base
   def set_auth_cookies
     cookies[:sinai_authenticated] = {
       value: create_encrypted_string.unpack('H*')[0].upcase,
-      expires: Time.zone.now + 25.years,
+      expires: Time.zone.now + 1.min,
       domain: ENV['DOMAIN']
     }
     cookies[:initialization_vector] = {
       value: cipher_iv.unpack('H*')[0].upcase,
-      expires: Time.zone.now + 25.years,
+      expires: Time.zone.now + 1.min,
       domain: ENV['DOMAIN']
     }
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -90,7 +90,7 @@ class ApplicationController < ActionController::Base
     }
     cookies[:initialization_vector] = {
       value: cipher_iv.unpack('H*')[0].upcase,
-      expires: Time.zone.now + 25.years,
+      expires: Time.zone.now + 1.mins,
       domain: ENV['DOMAIN']
     }
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -85,12 +85,12 @@ class ApplicationController < ActionController::Base
   def set_auth_cookies
     cookies[:sinai_authenticated_3day] = {
       value: create_encrypted_string.unpack('H*')[0].upcase,
-      expires: Time.zone.now + 3.days,
+      expires: Time.zone.now + 60,
       domain: ENV['DOMAIN']
     }
     cookies[:initialization_vector] = {
       value: cipher_iv.unpack('H*')[0].upcase,
-      expires: Time.zone.now + 3.days,
+      expires: Time.zone.now + 60,
       domain: ENV['DOMAIN']
     }
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -85,12 +85,12 @@ class ApplicationController < ActionController::Base
   def set_auth_cookies
     cookies[:sinai_authenticated] = {
       value: create_encrypted_string.unpack('H*')[0].upcase,
-      expires: Time.zone.now + 2.years,
+      expires: Time.zone.now + 25.years,
       domain: ENV['DOMAIN']
     }
     cookies[:initialization_vector] = {
       value: cipher_iv.unpack('H*')[0].upcase,
-      expires: Time.zone.now + 2.years,
+      expires: Time.zone.now + 25.years,
       domain: ENV['DOMAIN']
     }
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -37,9 +37,9 @@ class ApplicationController < ActionController::Base
   end
 
   def sinai_authn_check
-    return true if !Flipflop.sinai? || [login_path, version_path].include?(request.path) || sinai_authenticated?
+    return true if !Flipflop.sinai? || [login_path, version_path].include?(request.path) || sinai_authenticated_3day?
     if ENV['SINAI_ID_BYPASS'] # skip auth in development
-      cookies[:sinai_authenticated] = 'true'
+      cookies[:sinai_authenticated_3day] = 'true'
       return true
     end
     check_document_paths
@@ -65,8 +65,8 @@ class ApplicationController < ActionController::Base
     params[:sort] ||= 'score desc' unless params[:q].to_s.empty?
   end
 
-  def sinai_authenticated?
-    cookies[:sinai_authenticated]
+  def sinai_authenticated_3day?
+    cookies[:sinai_authenticated_3day]
   end
 
   def ucla_token?
@@ -83,7 +83,7 @@ class ApplicationController < ActionController::Base
   end
 
   def set_auth_cookies
-    cookies[:sinai_authenticated] = {
+    cookies[:sinai_authenticated_3day] = {
       value: create_encrypted_string.unpack('H*')[0].upcase,
       expires: Time.zone.now + 60,
       domain: ENV['DOMAIN']

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -85,12 +85,12 @@ class ApplicationController < ActionController::Base
   def set_auth_cookies
     cookies[:sinai_authenticated] = {
       value: create_encrypted_string.unpack('H*')[0].upcase,
-      expires: Time.zone.now + 1.min,
+      expires: Time.zone.now + 60,
       domain: ENV['DOMAIN']
     }
     cookies[:initialization_vector] = {
       value: cipher_iv.unpack('H*')[0].upcase,
-      expires: Time.zone.now + 1.min,
+      expires: Time.zone.now + 60,
       domain: ENV['DOMAIN']
     }
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -85,12 +85,12 @@ class ApplicationController < ActionController::Base
   def set_auth_cookies
     cookies[:sinai_authenticated] = {
       value: create_encrypted_string.unpack('H*')[0].upcase,
-      expires: Time.zone.now + 2.years,
+      expires: Time.zone.now + 60,
       domain: ENV['DOMAIN']
     }
     cookies[:initialization_vector] = {
       value: cipher_iv.unpack('H*')[0].upcase,
-      expires: Time.zone.now + 2.years,
+      expires: Time.zone.now + 60,
       domain: ENV['DOMAIN']
     }
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -37,9 +37,9 @@ class ApplicationController < ActionController::Base
   end
 
   def sinai_authn_check
-    return true if !Flipflop.sinai? || [login_path, version_path].include?(request.path) || sinai_authenticated?
+    return true if !Flipflop.sinai? || [login_path, version_path].include?(request.path) || sinai_authenticated_3day?
     if ENV['SINAI_ID_BYPASS'] # skip auth in development
-      cookies[:sinai_authenticated] = 'true'
+      cookies[:sinai_authenticated_3day] = 'true'
       return true
     end
     check_document_paths
@@ -65,8 +65,8 @@ class ApplicationController < ActionController::Base
     params[:sort] ||= 'score desc' unless params[:q].to_s.empty?
   end
 
-  def sinai_authenticated?
-    cookies[:sinai_authenticated]
+  def sinai_authenticated_3day?
+    cookies[:sinai_authenticated_3day]
   end
 
   def ucla_token?
@@ -83,14 +83,14 @@ class ApplicationController < ActionController::Base
   end
 
   def set_auth_cookies
-    cookies[:sinai_authenticated] = {
+    cookies[:sinai_authenticated_3day] = {
       value: create_encrypted_string.unpack('H*')[0].upcase,
-      expires: Time.zone.now + 25.years,
+      expires: Time.zone.now + 60,
       domain: ENV['DOMAIN']
     }
     cookies[:initialization_vector] = {
       value: cipher_iv.unpack('H*')[0].upcase,
-      expires: Time.zone.now + 25.years,
+      expires: Time.zone.now + 60,
       domain: ENV['DOMAIN']
     }
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -85,7 +85,7 @@ class ApplicationController < ActionController::Base
   def set_auth_cookies
     cookies[:sinai_authenticated] = {
       value: create_encrypted_string.unpack('H*')[0].upcase,
-      expires: Time.zone.now + 25.years,
+      expires: Time.zone.now + 1.mins,
       domain: ENV['DOMAIN']
     }
     cookies[:initialization_vector] = {

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -37,9 +37,9 @@ class ApplicationController < ActionController::Base
   end
 
   def sinai_authn_check
-    return true if !Flipflop.sinai? || [login_path, version_path].include?(request.path) || sinai_authenticated_3day?
+    return true if !Flipflop.sinai? || [login_path, version_path].include?(request.path) || sinai_authenticated?
     if ENV['SINAI_ID_BYPASS'] # skip auth in development
-      cookies[:sinai_authenticated_3day] = 'true'
+      cookies[:sinai_authenticated] = 'true'
       return true
     end
     check_document_paths
@@ -65,8 +65,8 @@ class ApplicationController < ActionController::Base
     params[:sort] ||= 'score desc' unless params[:q].to_s.empty?
   end
 
-  def sinai_authenticated_3day?
-    cookies[:sinai_authenticated_3day]
+  def sinai_authenticated?
+    cookies[:sinai_authenticated]
   end
 
   def ucla_token?
@@ -83,7 +83,7 @@ class ApplicationController < ActionController::Base
   end
 
   def set_auth_cookies
-    cookies[:sinai_authenticated_3day] = {
+    cookies[:sinai_authenticated] = {
       value: create_encrypted_string.unpack('H*')[0].upcase,
       expires: Time.zone.now + 25.years,
       domain: ENV['DOMAIN']

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -85,12 +85,12 @@ class ApplicationController < ActionController::Base
   def set_auth_cookies
     cookies[:sinai_authenticated_3day] = {
       value: create_encrypted_string.unpack('H*')[0].upcase,
-      expires: Time.zone.now + 60,
+      expires: Time.zone.now + 3.days,
       domain: ENV['DOMAIN']
     }
     cookies[:initialization_vector] = {
       value: cipher_iv.unpack('H*')[0].upcase,
-      expires: Time.zone.now + 60,
+      expires: Time.zone.now +3.days,
       domain: ENV['DOMAIN']
     }
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -85,12 +85,12 @@ class ApplicationController < ActionController::Base
   def set_auth_cookies
     cookies[:sinai_authenticated_3day] = {
       value: create_encrypted_string.unpack('H*')[0].upcase,
-      expires: Time.zone.now + 60,
+      expires: Time.zone.now + 3.days,
       domain: ENV['DOMAIN']
     }
     cookies[:initialization_vector] = {
       value: cipher_iv.unpack('H*')[0].upcase,
-      expires: Time.zone.now + 60,
+      expires: Time.zone.now + 3.days,
       domain: ENV['DOMAIN']
     }
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -85,12 +85,12 @@ class ApplicationController < ActionController::Base
   def set_auth_cookies
     cookies[:sinai_authenticated_3day] = {
       value: create_encrypted_string.unpack('H*')[0].upcase,
-      expires: Time.zone.now + 60,
+      expires: Time.zone.now + 25.years,
       domain: ENV['DOMAIN']
     }
     cookies[:initialization_vector] = {
       value: cipher_iv.unpack('H*')[0].upcase,
-      expires: Time.zone.now + 60,
+      expires: Time.zone.now + 25.years,
       domain: ENV['DOMAIN']
     }
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -85,12 +85,12 @@ class ApplicationController < ActionController::Base
   def set_auth_cookies
     cookies[:sinai_authenticated] = {
       value: create_encrypted_string.unpack('H*')[0].upcase,
-      expires: Time.zone.now + 25.years,
+      expires: Time.zone.now + 2.years,
       domain: ENV['DOMAIN']
     }
     cookies[:initialization_vector] = {
       value: cipher_iv.unpack('H*')[0].upcase,
-      expires: Time.zone.now + 25.years,
+      expires: Time.zone.now + 2.years,
       domain: ENV['DOMAIN']
     }
   end

--- a/app/views/catalog/_homepage_sinai.html.erb
+++ b/app/views/catalog/_homepage_sinai.html.erb
@@ -58,5 +58,5 @@
       </div>
     </div>
   </div>
-  <img src="https://test-iiif.sinaimanuscripts.library.ucla.edu/iiif/2/healthcheckimage/full/full/0/default.jpg" alt="lungs" width="500" height="600">image</image>
+  <img src="https://test-iiif.sinaimanuscripts-dev.library.ucla.edu/iiif/2/healthcheckimage/full/full/0/default.jpg" alt="lungs" width="500" height="600">image</image>
 </div>

--- a/app/views/catalog/_homepage_sinai.html.erb
+++ b/app/views/catalog/_homepage_sinai.html.erb
@@ -58,5 +58,5 @@
       </div>
     </div>
   </div>
-  <img src="https://test-iiif.sinaimanuscripts-dev.library.ucla.edu/iiif/2/healthcheckimage/full/full/0/default.jpg" alt="lungs" width="500" height="600">image</image>
+  <img src="https://iiif.sinaimanuscripts.library.ucla.edu/iiif/2/ark%3A%2F21198%2Fz18w4z1w%2Fkw02bh3h/full/!200,200/0/default.jpg" alt="lungs" width="500" height="600">image</image>
 </div>

--- a/app/views/catalog/_homepage_sinai.html.erb
+++ b/app/views/catalog/_homepage_sinai.html.erb
@@ -58,4 +58,5 @@
       </div>
     </div>
   </div>
+  <img src="https://test-iiif.sinaimanuscripts-dev.library.ucla.edu/iiif/2/healthcheckimage/full/full/0/default.jpg" alt="lungs" width="500" height="600">image</image>
 </div>

--- a/app/views/catalog/_homepage_sinai.html.erb
+++ b/app/views/catalog/_homepage_sinai.html.erb
@@ -58,5 +58,4 @@
       </div>
     </div>
   </div>
-  <img src="https://test-iiif.sinaimanuscripts-dev.library.ucla.edu/iiif/2/healthcheckimage/full/full/0/default.jpg" alt="lungs" width="500" height="600">image</image>
 </div>

--- a/app/views/catalog/_homepage_sinai.html.erb
+++ b/app/views/catalog/_homepage_sinai.html.erb
@@ -58,5 +58,5 @@
       </div>
     </div>
   </div>
-  <img src="https://test-iiif.sinaimanuscripts.library.ucla.edu/iiif/2/healthcheckimage/full/full/0/default.jpg" alt="lungs" width="500" height="600"> 
+  <img src="https://test-iiif.sinaimanuscripts.library.ucla.edu/iiif/2/healthcheckimage/full/full/0/default.jpg" alt="lungs" width="500" height="600">image</image>
 </div>

--- a/app/views/catalog/_homepage_sinai.html.erb
+++ b/app/views/catalog/_homepage_sinai.html.erb
@@ -58,4 +58,5 @@
       </div>
     </div>
   </div>
+  <img src="https://test-iiif.sinaimanuscripts.library.ucla.edu/iiif/2/healthcheckimage/full/full/0/default.jpg" alt="lungs" width="500" height="600"> 
 </div>

--- a/app/views/catalog/_homepage_sinai.html.erb
+++ b/app/views/catalog/_homepage_sinai.html.erb
@@ -58,5 +58,4 @@
       </div>
     </div>
   </div>
-  <img src="https://iiif.sinaimanuscripts.library.ucla.edu/iiif/2/ark%3A%2F21198%2Fz18w4z1w%2Fkw02bh3h/full/!200,200/0/default.jpg" alt="lungs" width="500" height="600">image</image>
 </div>

--- a/app/views/catalog/_index.html.erb
+++ b/app/views/catalog/_index.html.erb
@@ -8,7 +8,7 @@
     <%# THUMBNAIL %>
     <% if presenter(document).thumbnail.exists? && tn = presenter(document).thumbnail.thumbnail_tag({}, counter: document_counter_with_offset(document_counter)) %>
       <%# Thumnail NOT logged in %>
-      <% if !cookies[:sinai_authenticated] %>
+      <% if !cookies[:sinai_authenticated_3day] %>
         <div class='document__gallery-thumbnail document__gallery-thumbnail--sinai-generic'>
           <a href='#' data-toggle='modal' data-target='#exampleModalCenter'>
               <%= image_tag('sinai/sinai-generic-thumbnail.png', class: 'document__gallery-thumbnail--sinai-generic') %>
@@ -24,7 +24,7 @@
     <%# ----------------------------------------------- %>
 
     <%# METADATA %>
-    <% if !cookies[:sinai_authenticated] %>
+    <% if !cookies[:sinai_authenticated_3day] %>
       <%# Sinai NOT LOGGED IN %>
       <%# cookies[:request_original_url] = request.original_url %>
 

--- a/app/views/catalog/_index.html.erb
+++ b/app/views/catalog/_index.html.erb
@@ -8,7 +8,7 @@
     <%# THUMBNAIL %>
     <% if presenter(document).thumbnail.exists? && tn = presenter(document).thumbnail.thumbnail_tag({}, counter: document_counter_with_offset(document_counter)) %>
       <%# Thumnail NOT logged in %>
-      <% if !cookies[:sinai_authenticated_3day] %>
+      <% if !cookies[:sinai_authenticated] %>
         <div class='document__gallery-thumbnail document__gallery-thumbnail--sinai-generic'>
           <a href='#' data-toggle='modal' data-target='#exampleModalCenter'>
               <%= image_tag('sinai/sinai-generic-thumbnail.png', class: 'document__gallery-thumbnail--sinai-generic') %>
@@ -24,7 +24,7 @@
     <%# ----------------------------------------------- %>
 
     <%# METADATA %>
-    <% if !cookies[:sinai_authenticated_3day] %>
+    <% if !cookies[:sinai_authenticated] %>
       <%# Sinai NOT LOGGED IN %>
       <%# cookies[:request_original_url] = request.original_url %>
 

--- a/app/views/catalog/_index_gallery.html.erb
+++ b/app/views/catalog/_index_gallery.html.erb
@@ -1,7 +1,7 @@
 <% if Flipflop.sinai? %>
   <div class="document document__gallery-item document__gallery-item--sinai">
     <div class="document__gallery-item-wrapper">
-      <% if !cookies[:sinai_authenticated] %>
+      <% if !cookies[:sinai_authenticated_3day] %>
         <a href="#" class="document__gallery-item-thumbnail-link--sinai" data-toggle="modal" data-target="#exampleModalCenter">
           <%= image_tag("sinai/sinai-generic-thumbnail.png") %>
         </a>

--- a/app/views/catalog/_index_gallery.html.erb
+++ b/app/views/catalog/_index_gallery.html.erb
@@ -1,7 +1,7 @@
 <% if Flipflop.sinai? %>
   <div class="document document__gallery-item document__gallery-item--sinai">
     <div class="document__gallery-item-wrapper">
-      <% if !cookies[:sinai_authenticated_3day] %>
+      <% if !cookies[:sinai_authenticated] %>
         <a href="#" class="document__gallery-item-thumbnail-link--sinai" data-toggle="modal" data-target="#exampleModalCenter">
           <%= image_tag("sinai/sinai-generic-thumbnail.png") %>
         </a>

--- a/app/views/catalog/index.html.erb
+++ b/app/views/catalog/index.html.erb
@@ -1,6 +1,6 @@
 <!-- SINAI -->
 <% if Flipflop.sinai? %>
-<% if !cookies[:sinai_authenticated_3day] %>
+<% if !cookies[:sinai_authenticated] %>
 <%
       cookies[:requested_path] = request.original_url
       login_service = LoginService.new

--- a/app/views/catalog/index.html.erb
+++ b/app/views/catalog/index.html.erb
@@ -1,6 +1,6 @@
 <!-- SINAI -->
 <% if Flipflop.sinai? %>
-<% if !cookies[:sinai_authenticated] %>
+<% if !cookies[:sinai_authenticated_3day] %>
 <%
       cookies[:requested_path] = request.original_url
       login_service = LoginService.new

--- a/app/views/shared/header/_header_navbar.html.erb
+++ b/app/views/shared/header/_header_navbar.html.erb
@@ -15,7 +15,7 @@
         <li class='nav-item site-navbar__item--sinai'><%= link_to "Search#{image_tag('sinai-logos/search-icon-bold.svg', class: 'site-header__search-icon--sinai', alt: 'Search icon')}".html_safe, '/catalog?utf8=%E2%9C%93&q=&search_field=all_fields' %></li>
         <li class='nav-item site-navbar__item--sinai'><%= link_to 'About', about_path %></li>
 
-        <% if !cookies[:sinai_authenticated_3day] %>
+        <% if !cookies[:sinai_authenticated] %>
           <% cookies[:request_original_url] = request.original_url %>
           <li class='nav-item site-navbar__item--sinai'><%#= link_to 'Login', login_path %>
           <%= button_to 'LOGIN/REGISTER', ENV['SINAIID_URL'], params: { 'key' => ENV['SINAIID_UCLA_KEY'], callback_url: request.original_url, token: @token }, method: :post, class: 'btn btn_nav_link--sinai' %>

--- a/app/views/shared/header/_header_navbar.html.erb
+++ b/app/views/shared/header/_header_navbar.html.erb
@@ -15,7 +15,7 @@
         <li class='nav-item site-navbar__item--sinai'><%= link_to "Search#{image_tag('sinai-logos/search-icon-bold.svg', class: 'site-header__search-icon--sinai', alt: 'Search icon')}".html_safe, '/catalog?utf8=%E2%9C%93&q=&search_field=all_fields' %></li>
         <li class='nav-item site-navbar__item--sinai'><%= link_to 'About', about_path %></li>
 
-        <% if !cookies[:sinai_authenticated] %>
+        <% if !cookies[:sinai_authenticated_3day] %>
           <% cookies[:request_original_url] = request.original_url %>
           <li class='nav-item site-navbar__item--sinai'><%#= link_to 'Login', login_path %>
           <%= button_to 'LOGIN/REGISTER', ENV['SINAIID_URL'], params: { 'key' => ENV['SINAIID_UCLA_KEY'], callback_url: request.original_url, token: @token }, method: :post, class: 'btn btn_nav_link--sinai' %>

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe ApplicationController, type: :controller do
     allow(controller).to receive(:redirect_to)
     allow(controller).to receive(:request).and_return(instance_double('ActionDispatch::Request', path: '/'))
     allow(controller).to receive(:set_auth_cookies)
-    allow(controller).to receive(:sinai_authenticated_3day?).and_return(false)
+    allow(controller).to receive(:sinai_authenticated?).and_return(false)
     allow(controller).to receive(:version_path).and_return('/test_version')
     allow(controller).to receive(:solr_document_path).with('ark:').and_return('/catalog/ark:')
     allow(controller).to receive(:params).and_return(id: nil)
@@ -115,7 +115,7 @@ RSpec.describe ApplicationController, type: :controller do
 
     context 'if we are already authenticated' do
       before do
-        allow(controller).to receive(:sinai_authenticated_3day?).and_return(true)
+        allow(controller).to receive(:sinai_authenticated?).and_return(true)
       end
       it 'allows Rails to continue' do
         expect(controller.sinai_authn_check).to be true
@@ -125,7 +125,7 @@ RSpec.describe ApplicationController, type: :controller do
     context 'if the requested path is solr_document_path' do
       before do
         allow(controller).to receive(:params).and_return(id: 'ark:')
-        allow(controller).to receive(:sinai_authenticated_3day?).and_return(false)
+        allow(controller).to receive(:sinai_authenticated?).and_return(false)
         allow(controller).to receive(:request).and_return(instance_double('ActionDispatch::Request', path: controller.solr_document_path('ark:')))
       end
       it 'redirects to requested path' do
@@ -195,7 +195,7 @@ RSpec.describe ApplicationController, type: :controller do
   end # describe ucla_token?
 
   describe 'set_auth_cookies' do
-    context 'creates the sinai_authenticated_3day cookie' do
+    context 'creates the sinai_authenticated cookie' do
       let(:cookies) { {} }
       before do
         allow(controller).to receive(:cookies).and_return(cookies)
@@ -207,14 +207,14 @@ RSpec.describe ApplicationController, type: :controller do
         allow(controller).to receive(:cipher_iv).and_return('mock_cipher_iv')
       end
 
-      it 'sets the sinai_authenticated_3day cookie value' do
+      it 'sets the sinai_authenticated cookie value' do
         controller.set_auth_cookies
-        expect(cookies[:sinai_authenticated_3day][:value]).to eq('mock_encrypted_string'.unpack('H*')[0].upcase)
+        expect(cookies[:sinai_authenticated][:value]).to eq('mock_encrypted_string'.unpack('H*')[0].upcase)
       end
 
-      it 'sets an expiration date for the sinai_authenticated_3day cookie' do
+      it 'sets an expiration date for the sinai_authenticated cookie' do
         controller.set_auth_cookies
-        expect(cookies[:sinai_authenticated_3day][:expires]).to be_kind_of(Time)
+        expect(cookies[:sinai_authenticated][:expires]).to be_kind_of(Time)
       end
 
       it 'sets the initialization_vector cookie value' do

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe ApplicationController, type: :controller do
     allow(controller).to receive(:redirect_to)
     allow(controller).to receive(:request).and_return(instance_double('ActionDispatch::Request', path: '/'))
     allow(controller).to receive(:set_auth_cookies)
-    allow(controller).to receive(:sinai_authenticated?).and_return(false)
+    allow(controller).to receive(:sinai_authenticated_3day?).and_return(false)
     allow(controller).to receive(:version_path).and_return('/test_version')
     allow(controller).to receive(:solr_document_path).with('ark:').and_return('/catalog/ark:')
     allow(controller).to receive(:params).and_return(id: nil)
@@ -115,7 +115,7 @@ RSpec.describe ApplicationController, type: :controller do
 
     context 'if we are already authenticated' do
       before do
-        allow(controller).to receive(:sinai_authenticated?).and_return(true)
+        allow(controller).to receive(:sinai_authenticated_3day?).and_return(true)
       end
       it 'allows Rails to continue' do
         expect(controller.sinai_authn_check).to be true
@@ -125,7 +125,7 @@ RSpec.describe ApplicationController, type: :controller do
     context 'if the requested path is solr_document_path' do
       before do
         allow(controller).to receive(:params).and_return(id: 'ark:')
-        allow(controller).to receive(:sinai_authenticated?).and_return(false)
+        allow(controller).to receive(:sinai_authenticated_3day?).and_return(false)
         allow(controller).to receive(:request).and_return(instance_double('ActionDispatch::Request', path: controller.solr_document_path('ark:')))
       end
       it 'redirects to requested path' do
@@ -195,7 +195,7 @@ RSpec.describe ApplicationController, type: :controller do
   end # describe ucla_token?
 
   describe 'set_auth_cookies' do
-    context 'creates the sinai_authenticated cookie' do
+    context 'creates the sinai_authenticated_3day cookie' do
       let(:cookies) { {} }
       before do
         allow(controller).to receive(:cookies).and_return(cookies)
@@ -207,14 +207,14 @@ RSpec.describe ApplicationController, type: :controller do
         allow(controller).to receive(:cipher_iv).and_return('mock_cipher_iv')
       end
 
-      it 'sets the sinai_authenticated cookie value' do
+      it 'sets the sinai_authenticated_3day cookie value' do
         controller.set_auth_cookies
-        expect(cookies[:sinai_authenticated][:value]).to eq('mock_encrypted_string'.unpack('H*')[0].upcase)
+        expect(cookies[:sinai_authenticated_3day][:value]).to eq('mock_encrypted_string'.unpack('H*')[0].upcase)
       end
 
-      it 'sets an expiration date for the sinai_authenticated cookie' do
+      it 'sets an expiration date for the sinai_authenticated_3day cookie' do
         controller.set_auth_cookies
-        expect(cookies[:sinai_authenticated][:expires]).to be_kind_of(Time)
+        expect(cookies[:sinai_authenticated_3day][:expires]).to be_kind_of(Time)
       end
 
       it 'sets the initialization_vector cookie value' do


### PR DESCRIPTION
Connected to [APPS-654](https://jira.library.ucla.edu/browse/APPS-815)
Develop a method to obviate all existing login cookies with 25-year expiry and replace them with cookies having a 3-day expiry.

Acceptance Criteria:


- [x] users must log in again three days after last login.
- [x] new cookies are set to expire in 3 days
- [x] old, non-expiring cookies aren't accepted

---

#### Files
 README.md
+ `app/controllers/application_controller.rb`
+ `app/views/catalog/_index.html.erb`
+ `app/views/catalog/_index_gallery.html.erb`
+ `app/views/catalog/index.html.erb`
+ `app/views/shared/header/_header_navbar.html.erb`
+ `spec/controllers/application_controller_spec.rb`

---

![image](https://user-images.githubusercontent.com/2350153/119207757-338f9880-ba54-11eb-8412-99c1198878b0.png)

