### PR TITLE
Sinai: Add the fields for "Dimensions" and "Weight" to the item page

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -236,6 +236,7 @@ class CatalogController < ApplicationController
     # 'Book format'
     config.add_show_field 'medium_tesim', label: 'Medium'
     config.add_show_field 'extent_tesim', label: 'Extent'
+    config.add_show_field 'format_extent_tesim', label: 'Extent'
     config.add_show_field 'dimensions_tesim', label: 'Dimensions'
     config.add_show_field 'page_layout_ssim', label: 'Page layout'
     config.add_show_field 'binding_note_ssi', label: 'Binding note'

--- a/config/metadata-sinai/codicology_metadata.yml
+++ b/config/metadata-sinai/codicology_metadata.yml
@@ -1,7 +1,7 @@
 # These fields are in order of display
 
 # Sinai only - Codicology
-extent_tesim: 'Extent'
+format_extent_tesim: 'Extent'
 collation_tesim: 'Collation'
 form_tesim: 'Form'
 support_tesim: 'Support'

--- a/config/metadata-sinai/overview_metadata.yml
+++ b/config/metadata-sinai/overview_metadata.yml
@@ -3,7 +3,7 @@
 # Sinai only - Overview
 place_of_origin_tesim: 'Place of origin'
 date_created_tesim: 'Date created'
-extent_tesim: 'Extent'
+format_extent_tesim: 'Extent'
 form_tesim: 'Form'
 human_readable_language_tesim: 'Language'
 writing_system_tesim: 'Writing system'

--- a/spec/presenters/sinai/codicology_metadata_presenter_spec.rb
+++ b/spec/presenters/sinai/codicology_metadata_presenter_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 RSpec.describe Sinai::CodicologyMetadataPresenter do
   let(:solr_doc) do
     {
-      'extent_tesim' => 'Extent',
+      'format_extent_tesim' => 'Extent',
       'collation_tesim' => 'Collation',
       'form_tesim' => 'Form',
       'support_tesim' => 'Support',

--- a/spec/presenters/sinai/codicology_metadata_presenter_spec.rb
+++ b/spec/presenters/sinai/codicology_metadata_presenter_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Sinai::CodicologyMetadataPresenter do
   end
   let(:solr_doc_missing_items) do
     {
-      'extent_tesim' => 'Extent',
+      'format_extent_tesim' => 'Extent',
       'collation_tesim' => 'Collation',
       'form_sim' => 'Form',
       'support_tesim' => 'Support',
@@ -35,7 +35,7 @@ RSpec.describe Sinai::CodicologyMetadataPresenter do
   context 'with a solr document containing codicology metadata' do
     describe '#terms' do
       it 'returns the Extent Key' do
-        expect(config['extent_tesim'].to_s).to eq('Extent')
+        expect(config['format_extent_tesim'].to_s).to eq('Extent')
       end
 
       it 'returns the Collation Key' do

--- a/spec/presenters/sinai/overview_metadata_presenter_spec.rb
+++ b/spec/presenters/sinai/overview_metadata_presenter_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Sinai::OverviewMetadataPresenter do
       end
 
       it 'returns the Extent Key' do
-        expect(config['extent_tesim'].to_s).to eq('Extent')
+        expect(config['format_extent_tesim'].to_s).to eq('Extent')
       end
 
       it 'returns the Form Key' do

--- a/spec/presenters/sinai/overview_metadata_presenter_spec.rb
+++ b/spec/presenters/sinai/overview_metadata_presenter_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Sinai::OverviewMetadataPresenter do
     {
       'place_of_origin_tesim' => 'Place of origin',
       'date_created_tesim' => 'Date created',
-      'extent_tesim' => 'Extent',
+      'format_extent_tesim' => 'Extent',
       'form_tesim' => 'Form',
       'human_readable_language_tesim' => 'Language',
       'writing_system_tesim' => 'Writing system',
@@ -20,7 +20,7 @@ RSpec.describe Sinai::OverviewMetadataPresenter do
     {
       'place_of_origin_tesim' => 'Place of origin',
       'date_created_tesim' => 'Date created',
-      'extent_tesim' => 'Extent',
+      'format_extent_tesim' => 'Extent',
       'form_tesim' => 'Form',
       'human_readable_language_tesim' => 'Language'
     }


### PR DESCRIPTION
Connected to [APPS-1205](https://jira.library.ucla.edu/browse/APPS-1205)

Acceptance criteria:

- [x] On an item page under the Extent display label, the field values for format.extent, format.dimensions, and format.weight are printed and separated by a vertical pipe "|"