### PR TITLE
APPS-1197 Sinai: Update so users can view item page without login

### DIFF
--- a/app/assets/stylesheets/theme_sinai/components/_si-auth-modal.scss
+++ b/app/assets/stylesheets/theme_sinai/components/_si-auth-modal.scss
@@ -5,7 +5,12 @@
 
 .si-auth-modal-btn-group {
   display: flex;
-  justify-content: space-between;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  justify-content: flex-start;
+  align-content: center;
+  align-items: center;
+
   width: 100%;
-  max-width: 165px;
+  max-width: 200px;
 }

--- a/app/assets/stylesheets/theme_sinai/components/_si-auth-modal.scss
+++ b/app/assets/stylesheets/theme_sinai/components/_si-auth-modal.scss
@@ -5,22 +5,21 @@
 
 .si-auth-modal-btn-group {
   display: flex;
-  flex-direction: row;
-  flex-wrap: nowrap;
-  justify-content: flex-start;
-  align-content: center;
   align-items: center;
-
+  justify-content: flex-start;
+  margin-bottom: 10px;
   width: 100%;
   max-width: 200px;
-  margin-bottom: 10px;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  align-content: center;
 }
 
 .si-media-viewer-login {
   display: flex;
-  flex-direction: row;
-  justify-content: center;
   align-items: center;
+  justify-content: center;
+  flex-direction: row;
 }
 
 .si-auth-text {

--- a/app/assets/stylesheets/theme_sinai/components/_si-auth-modal.scss
+++ b/app/assets/stylesheets/theme_sinai/components/_si-auth-modal.scss
@@ -13,4 +13,5 @@
 
   width: 100%;
   max-width: 200px;
+  margin-bottom: 10px;
 }

--- a/app/assets/stylesheets/theme_sinai/components/_si-auth-modal.scss
+++ b/app/assets/stylesheets/theme_sinai/components/_si-auth-modal.scss
@@ -15,3 +15,14 @@
   max-width: 200px;
   margin-bottom: 10px;
 }
+
+.si-media-viewer-login {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+}
+
+.si-auth-text {
+  margin-right: 16px;
+}

--- a/app/assets/stylesheets/theme_sinai/elements/_si-buttons.scss
+++ b/app/assets/stylesheets/theme_sinai/elements/_si-buttons.scss
@@ -36,6 +36,7 @@
 }
 .btn-modal {
   margin-right: 10px;
+  font-size: 1.2rem;
 }
 
 .btn-outline-sinai--primary:visited:hover {

--- a/app/assets/stylesheets/theme_sinai/elements/_si-buttons.scss
+++ b/app/assets/stylesheets/theme_sinai/elements/_si-buttons.scss
@@ -34,6 +34,7 @@
     font-weight: 900;
   }
 }
+
 .btn-modal {
   margin-right: 10px;
   font-size: 1.2rem;

--- a/app/assets/stylesheets/theme_sinai/elements/_si-buttons.scss
+++ b/app/assets/stylesheets/theme_sinai/elements/_si-buttons.scss
@@ -34,6 +34,9 @@
     font-weight: 900;
   }
 }
+.btn-modal {
+  margin-right: 10px;
+}
 
 .btn-outline-sinai--primary:visited:hover {
   color: $white;

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -125,8 +125,8 @@ class ApplicationController < ActionController::Base
       @iv ||= cipher.random_iv
     end
 
-    # def redirect_target
-    #   cookies[:request_original_url] = request.original_url
-    #   "/"
-    # end
+  # def redirect_target
+  #   cookies[:request_original_url] = request.original_url
+  #   "/"
+  # end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -42,15 +42,15 @@ class ApplicationController < ActionController::Base
       cookies[:sinai_authenticated_3day] = 'true'
       return true
     end
-    check_document_paths
+    # check_document_paths
     return unless ucla_token?
     set_auth_cookies
     redirect_to cookies[:requested_path]
   end
 
-  def check_document_paths
-    redirect_to redirect_target if params[:id] && [solr_document_path(params[:id])].include?(request.path) # check if someone bookmarked the show page
-  end
+  # def check_document_paths
+  #   redirect_to redirect_target if params[:id] && [solr_document_path(params[:id])].include?(request.path) # check if someone bookmarked the show page
+  # end
 
   def banner_cookie?
     cookies[:banner_display_option]
@@ -125,8 +125,8 @@ class ApplicationController < ActionController::Base
       @iv ||= cipher.random_iv
     end
 
-    def redirect_target
-      cookies[:request_original_url] = request.original_url
-      "/"
-    end
+    # def redirect_target
+    #   cookies[:request_original_url] = request.original_url
+    #   "/"
+    # end
 end

--- a/app/views/catalog/_index.html.erb
+++ b/app/views/catalog/_index.html.erb
@@ -27,7 +27,6 @@
     <%# cookies[:request_original_url] = request.original_url %>
 
     <div class='metadata-wrapper-index--sinai'>
-
       <header class='header-index--sinai'>
         <%= render 'catalog/index_results/modal', document: document %>
         <%# link the header to the block access modal%>

--- a/app/views/catalog/_index.html.erb
+++ b/app/views/catalog/_index.html.erb
@@ -22,9 +22,9 @@
   <%# ----------------------------------------------- %>
 
   <%# METADATA %>
-  <% if cookies[:sinai_authenticated_3day] %>
+  <% if !cookies[:sinai_authenticated_3day] %>
     <%# Sinai NOT LOGGED IN %>
-    <%# !cookies[:request_original_url] = request.original_url %>
+    <%# cookies[:request_original_url] = request.original_url %>
 
     <div class='metadata-wrapper-index--sinai'>
 

--- a/app/views/catalog/_index.html.erb
+++ b/app/views/catalog/_index.html.erb
@@ -29,6 +29,7 @@
     <div class='metadata-wrapper-index--sinai'>
 
       <header class='header-index--sinai'>
+        <%= render 'catalog/index_results/modal', document: document %>
         <%# link the header to the block access modal%>
         <a href='#' data-toggle='modal' data-target='#exampleModalCenter'>
           <%= render 'catalog/index_results/header', document: document %>

--- a/app/views/catalog/_index.html.erb
+++ b/app/views/catalog/_index.html.erb
@@ -22,7 +22,7 @@
   <%# ----------------------------------------------- %>
 
   <%# METADATA %>
-  <% if !cookies[:sinai_authenticated_3day] %>
+  <% if cookies[:sinai_authenticated_3day] %>
     <%# Sinai NOT LOGGED IN %>
     <%# cookies[:request_original_url] = request.original_url %>
 

--- a/app/views/catalog/_index.html.erb
+++ b/app/views/catalog/_index.html.erb
@@ -24,7 +24,7 @@
   <%# METADATA %>
   <% if cookies[:sinai_authenticated_3day] %>
     <%# Sinai NOT LOGGED IN %>
-    <%# cookies[:request_original_url] = request.original_url %>
+    <%# !cookies[:request_original_url] = request.original_url %>
 
     <div class='metadata-wrapper-index--sinai'>
 

--- a/app/views/catalog/_index_gallery.html.erb
+++ b/app/views/catalog/_index_gallery.html.erb
@@ -7,6 +7,7 @@
         </a>
         <div class="caption document__gallery-item-text-wrapper document__gallery-item-text-wrapper--sinai">
         <header class="header-gallery--sinai">
+        <%= render 'catalog/index_results/modal', document: document %>
           <a href="#" data-toggle="modal" data-target="#exampleModalCenter">
             <%= document['shelfmark_ssi'] %>
           </a>

--- a/app/views/catalog/_media_viewer.html.erb
+++ b/app/views/catalog/_media_viewer.html.erb
@@ -10,6 +10,7 @@
     <%= button_to 'Login', ENV['SINAIID_URL'], params: { 'key' => ENV['SINAIID_UCLA_KEY'], callback_url: request.original_url, token: @token }, method: :post, class: 'btn-base btn-outline-sinai--primary' %>
     <%= link_to 'Register', 'https://sinai-id.org/users/sign_up', class: 'btn-base btn-outline-sinai--primary' %>
   </div>
+  
     <% elsif cookies[:sinai_authenticated_3day] %>
         <div class='media-viewer-container media-viewer-container--sinai'>
           <% iiif_service = IiifService.new %>

--- a/app/views/catalog/_media_viewer.html.erb
+++ b/app/views/catalog/_media_viewer.html.erb
@@ -1,29 +1,27 @@
 <% if can?(:read, document) %>
-  <% if Flipflop.sinai? %>
-    <div class='media-viewer-container media-viewer-container--sinai'>
-      <% iiif_service = IiifService.new %>
-      <iframe
-        class='media-viewer-iframe'
-        src="<%= iiif_service.src(request, document) %>"
-        width='924px'
-        height='668px'
-        id='media-viewer-iframe'
-        allowfullscreen
-        frameborder='0'>
-      </iframe>
-    </div>
-  <% else %>
-    <div class='media-viewer-container'>
-      <% iiif_service = IiifService.new %>
-      <iframe
-        class='media-viewer-iframe'
-        src="<%= iiif_service.src(request, document) %>"
-        width='924px'
-        height='668px'
-        id='media-viewer-iframe'
-        allowfullscreen
-        frameborder='0'>
-      </iframe>
-    </div>
-  <% end %>
+  <% if !cookies[:sinai_authenticated_3day] %>
+  <%
+      cookies[:requested_path] = request.original_url
+      login_service = LoginService.new
+      @token = login_service.create_token
+%>
+    <div class='si-media-viewer-login'>Login required to view manuscript images.</div>
+    <div class="si-auth-modal-btn-group">
+    <%= button_to 'Login', ENV['SINAIID_URL'], params: { 'key' => ENV['SINAIID_UCLA_KEY'], callback_url: request.original_url, token: @token }, method: :post, class: 'btn-base btn-outline-sinai--primary' %>
+    <%= link_to 'Register', 'https://sinai-id.org/users/sign_up', class: 'btn-base btn-outline-sinai--primary' %>
+  </div>
+    <% elsif cookies[:sinai_authenticated_3day] %>
+        <div class='media-viewer-container media-viewer-container--sinai'>
+          <% iiif_service = IiifService.new %>
+          <iframe
+            class='media-viewer-iframe'
+            src="<%= iiif_service.src(request, document) %>"
+            width='924px'
+            height='668px'
+            id='media-viewer-iframe'
+            allowfullscreen
+            frameborder='0'>
+          </iframe>
+        </div>
+    <% end %>
 <% end %>

--- a/app/views/catalog/_media_viewer.html.erb
+++ b/app/views/catalog/_media_viewer.html.erb
@@ -1,29 +1,29 @@
 <% if can?(:read, document) %>
   <% if !cookies[:sinai_authenticated_3day] %>
-  <%
-    cookies[:requested_path] = request.original_url
-    login_service = LoginService.new
-    @token = login_service.create_token
-  %>
-  <div class='si-media-viewer-login'>
-  <div class="si-auth-text">Login required to view manuscript images.</div>
-    <div class="si-auth-modal-btn-group">
-    <%= button_to 'Login', ENV['SINAIID_URL'], params: { 'key' => ENV['SINAIID_UCLA_KEY'], callback_url: request.original_url, token: @token }, method: :post, class: 'btn-base btn-outline-sinai--primary btn-modal' %>
-    <%= link_to 'Register', 'https://sinai-id.org/users/sign_up', class: 'btn-base btn-outline-sinai--primary btn-modal' %>
-  </div>
-  </div>
-    <% elsif cookies[:sinai_authenticated_3day] %>
-        <div class='media-viewer-container media-viewer-container--sinai'>
-          <% iiif_service = IiifService.new %>
-          <iframe
-            class='media-viewer-iframe'
-            src="<%= iiif_service.src(request, document) %>"
-            width='924px'
-            height='668px'
-            id='media-viewer-iframe'
-            allowfullscreen
-            frameborder='0'>
-          </iframe>
-        </div>
-    <% end %>
+    <%
+      cookies[:requested_path] = request.original_url
+      login_service = LoginService.new
+      @token = login_service.create_token
+    %>
+    <div class='si-media-viewer-login'>
+      <div class="si-auth-text">Login required to view manuscript images.</div>
+        <div class="si-auth-modal-btn-group">
+          <%= button_to 'Login', ENV['SINAIID_URL'], params: { 'key' => ENV['SINAIID_UCLA_KEY'], callback_url: request.original_url, token: @token }, method: :post, class: 'btn-base btn-outline-sinai--primary  btn-modal'   %>
+          <%= link_to 'Register', 'https://sinai-id.org/users/sign_up', class:    'btn-base btn-outline-sinai--primary btn-modal' %>
+      </div>
+    </div>
+  <% else %>
+    <div class='media-viewer-container media-viewer-container--sinai'>
+      <% iiif_service = IiifService.new %>
+      <iframe
+        class='media-viewer-iframe'
+        src="<%= iiif_service.src(request, document) %>"
+        width='924px'
+        height='668px'
+        id='media-viewer-iframe'
+        allowfullscreen
+        frameborder='0'>
+      </iframe>
+      </div>
+  <% end %>
 <% end %>

--- a/app/views/catalog/_media_viewer.html.erb
+++ b/app/views/catalog/_media_viewer.html.erb
@@ -8,8 +8,8 @@
     <div class='si-media-viewer-login'>
       <div class="si-auth-text">Login required to view manuscript images.</div>
         <div class="si-auth-modal-btn-group">
-          <%= button_to 'Login', ENV['SINAIID_URL'], params: { 'key' => ENV['SINAIID_UCLA_KEY'], callback_url: request.original_url, token: @token }, method: :post, class: 'btn-base btn-outline-sinai--primary  btn-modal'   %>
-          <%= link_to 'Register', 'https://sinai-id.org/users/sign_up', class:    'btn-base btn-outline-sinai--primary btn-modal' %>
+          <%= button_to 'Login', ENV['SINAIID_URL'], params: { 'key' => ENV['SINAIID_UCLA_KEY'], callback_url: request.original_url, token: @token }, method: :post, class: 'btn-base btn-outline-sinai--primary  btn-modal' %>
+          <%= link_to 'Register', 'https://sinai-id.org/users/sign_up', class: 'btn-base btn-outline-sinai--primary btn-modal' %>
       </div>
     </div>
   <% else %>

--- a/app/views/catalog/_media_viewer.html.erb
+++ b/app/views/catalog/_media_viewer.html.erb
@@ -1,4 +1,5 @@
 <% if can?(:read, document) %>
+<%# --------- Sinai Not Logged in ----- %>
   <% if !cookies[:sinai_authenticated_3day] %>
     <%
       cookies[:requested_path] = request.original_url
@@ -13,6 +14,7 @@
       </div>
     </div>
   <% else %>
+  <%# --------- Sinai Logged in ----- %>
     <div class='media-viewer-container media-viewer-container--sinai'>
       <% iiif_service = IiifService.new %>
       <iframe

--- a/app/views/catalog/_media_viewer.html.erb
+++ b/app/views/catalog/_media_viewer.html.erb
@@ -7,10 +7,9 @@
 %>
     <div class='si-media-viewer-login'>Login required to view manuscript images.</div>
     <div class="si-auth-modal-btn-group">
-    <%= button_to 'Login', ENV['SINAIID_URL'], params: { 'key' => ENV['SINAIID_UCLA_KEY'], callback_url: request.original_url, token: @token }, method: :post, class: 'btn-base btn-outline-sinai--primary' %>
-    <%= link_to 'Register', 'https://sinai-id.org/users/sign_up', class: 'btn-base btn-outline-sinai--primary' %>
+    <%= button_to 'Login', ENV['SINAIID_URL'], params: { 'key' => ENV['SINAIID_UCLA_KEY'], callback_url: request.original_url, token: @token }, method: :post, class: 'btn-base btn-outline-sinai--primary btn-modal' %>
+    <%= link_to 'Register', 'https://sinai-id.org/users/sign_up', class: 'btn-base btn-outline-sinai--primary btn-modal' %>
   </div>
-  
     <% elsif cookies[:sinai_authenticated_3day] %>
         <div class='media-viewer-container media-viewer-container--sinai'>
           <% iiif_service = IiifService.new %>

--- a/app/views/catalog/_media_viewer.html.erb
+++ b/app/views/catalog/_media_viewer.html.erb
@@ -1,14 +1,16 @@
 <% if can?(:read, document) %>
   <% if !cookies[:sinai_authenticated_3day] %>
   <%
-      cookies[:requested_path] = request.original_url
-      login_service = LoginService.new
-      @token = login_service.create_token
-%>
-    <div class='si-media-viewer-login'>Login required to view manuscript images.</div>
+    cookies[:requested_path] = request.original_url
+    login_service = LoginService.new
+    @token = login_service.create_token
+  %>
+  <div class='si-media-viewer-login'>
+  <div class="si-auth-text">Login required to view manuscript images.</div>
     <div class="si-auth-modal-btn-group">
     <%= button_to 'Login', ENV['SINAIID_URL'], params: { 'key' => ENV['SINAIID_UCLA_KEY'], callback_url: request.original_url, token: @token }, method: :post, class: 'btn-base btn-outline-sinai--primary btn-modal' %>
     <%= link_to 'Register', 'https://sinai-id.org/users/sign_up', class: 'btn-base btn-outline-sinai--primary btn-modal' %>
+  </div>
   </div>
     <% elsif cookies[:sinai_authenticated_3day] %>
         <div class='media-viewer-container media-viewer-container--sinai'>

--- a/app/views/catalog/_show.html.erb
+++ b/app/views/catalog/_show.html.erb
@@ -1,6 +1,6 @@
-<%# --------- Back to Search Results ----- %>
-<div class='item-page__metadata-wrapper-results--sinai'>
-    <%= link_back_to_catalog label: '← Back to Search Results', class:'si-link si-link-search-results' %>
+<%# --------- Back to Search Results ----- %>   
+<div class='item-page__metadata-wrapper-results--sinai'>  
+  <%= link_back_to_catalog label: '← Back to Search Results', class: 'si-link si-link-search-results' %>  
   <%# ---------- IIIF & Tooltip ------------ %>
   <% if cookies[:sinai_authenticated_3day] %>
     <div class='si-link-iiif'>
@@ -15,15 +15,14 @@
     </div>
   <% end %>
 </div>
-<%# ----------- Shelfmark --------------- %>
+<%# ----------- Shelfmark --------------- %>  
 <div class='title-row-show--siani'>
   <%= @document[:shelfmark_ssi] %>
 </div>
 <div class='item-page__metadata-wrapper'>
-    <%= render 'catalog/work_record--sinai/primary_metadata', document:document %>
-    <%= render 'catalog/work_record--sinai/secondary_metadata', document:document %>
+  <%= render 'catalog/work_record--sinai/primary_metadata', document: document %>
+  <%= render 'catalog/work_record--sinai/secondary_metadata', document: document %>
 </div>
-
 
 <script>
 document.addEventListener("DOMContentLoaded", function(event) {

--- a/app/views/catalog/_show.html.erb
+++ b/app/views/catalog/_show.html.erb
@@ -1,37 +1,29 @@
-<% if Flipflop.sinai? %>
-  <%# --------- Back to Search Results ----- %>
-
-  <div class='item-page__metadata-wrapper-results--sinai'>
-    <%= link_back_to_catalog label: '← Back to Search Results', class: 'si-link si-link-search-results' %>
-    <%#= link_to image_tag('iiif-logo.png', alt: 'IIIF Manifest'), @document[:iiif_manifest_url_ssi], class: 'si-link-iiif' %>
-
-    <%# ---------- IIIF & Tooltip ------------ %>
-    <% if cookies[:sinai_authenticated_3day] %>
-      <div class='si-link-iiif'>
-        <% if @document["viscodex_ssi"] %>
-          <div class='si-link-viscodex' data-toggle="tooltip" data-placement="bottom" data-html="true" title="Click to view collation viewer">
-            <%= link_to image_tag('sinai-logos/logo-viscodex.png'), @document[:viscodex_ssi], target: '_blank', alt: 'Collation Viewer' %>
-          </div>
-        <% end %>
-        <%= link_to image_tag('iiif-logo.png'), @document[:iiif_manifest_url_ssi], target: '_blank', alt: 'IIIF Manifest' %>
+<%# --------- Back to Search Results ----- %>
+<div class='item-page__metadata-wrapper-results--sinai'>
+    <%= link_back_to_catalog label: '← Back to Search Results', class:'si-link si-link-search-results' %>
+  <%# ---------- IIIF & Tooltip ------------ %>
+  <% if cookies[:sinai_authenticated_3day] %>
+    <div class='si-link-iiif'>
+      <% if @document["viscodex_ssi"] %>
+        <div class='si-link-viscodex' data-toggle="tooltip" data-placement="bottom" data-html="true" title="Click to  viewcollation viewer">
+          <%= link_to image_tag('sinai-logos/logo-viscodex.png'), @document[:viscodex_ssi], target: '_blank', alt: 'Collation Viewer' %>
         </div>
       <% end %>
       <div class="si-link-iiif-manifest" data-toggle="tooltip" data-placement="bottom" data-html="true" title="IIIF Manifest">
         <%= link_to image_tag('iiif-logo.png'), @document[:iiif_manifest_url_ssi], target: '_blank', alt: 'IIIF Manifest' %>
       </div>
-    <% end %>
-  </div>
+    </div>
+  <% end %>
+</div>
+<%# ----------- Shelfmark --------------- %>
+<div class='title-row-show--siani'>
+  <%= @document[:shelfmark_ssi] %>
+</div>
+<div class='item-page__metadata-wrapper'>
+    <%= render 'catalog/work_record--sinai/primary_metadata', document:document %>
+    <%= render 'catalog/work_record--sinai/secondary_metadata', document:document %>
+</div>
 
-  <%# ----------- Shelfmark --------------- %>
-  <div class='title-row-show--siani'>
-    <%= @document[:shelfmark_ssi] %>
-  </div>
-
-  <div class='item-page__metadata-wrapper'>
-    <%= render 'catalog/work_record--sinai/primary_metadata', document: document %>
-    <%= render 'catalog/work_record--sinai/secondary_metadata', document: document %>
-  </div>
-<% end %>
 
 <script>
 document.addEventListener("DOMContentLoaded", function(event) {

--- a/app/views/catalog/_show.html.erb
+++ b/app/views/catalog/_show.html.erb
@@ -1,6 +1,6 @@
-<%# --------- Back to Search Results ----- %>   
-<div class='item-page__metadata-wrapper-results--sinai'>  
-  <%= link_back_to_catalog label: '← Back to Search Results', class: 'si-link si-link-search-results' %>  
+<%# --------- Back to Search Results ----- %>
+<div class='item-page__metadata-wrapper-results--sinai'>
+  <%= link_back_to_catalog label: '← Back to Search Results', class: 'si-link si-link-search-results' %>
   <%# ---------- IIIF & Tooltip ------------ %>
   <% if cookies[:sinai_authenticated_3day] %>
     <div class='si-link-iiif'>
@@ -15,7 +15,7 @@
     </div>
   <% end %>
 </div>
-<%# ----------- Shelfmark --------------- %>  
+<%# ----------- Shelfmark --------------- %>
 <div class='title-row-show--siani'>
   <%= @document[:shelfmark_ssi] %>
 </div>

--- a/app/views/catalog/_show.html.erb
+++ b/app/views/catalog/_show.html.erb
@@ -6,16 +6,20 @@
     <%#= link_to image_tag('iiif-logo.png', alt: 'IIIF Manifest'), @document[:iiif_manifest_url_ssi], class: 'si-link-iiif' %>
 
     <%# ---------- IIIF & Tooltip ------------ %>
-    <div class='si-link-iiif'>
-      <% if @document["viscodex_ssi"] %>
-        <div class='si-link-viscodex' data-toggle="tooltip" data-placement="bottom" data-html="true" title="Click to view collation viewer">
-          <%= link_to image_tag('sinai-logos/logo-viscodex.png'), @document[:viscodex_ssi], target: '_blank', alt: 'Collation Viewer' %>
+    <% if cookies[:sinai_authenticated_3day] %>
+      <div class='si-link-iiif'>
+        <% if @document["viscodex_ssi"] %>
+          <div class='si-link-viscodex' data-toggle="tooltip" data-placement="bottom" data-html="true" title="Click to view collation viewer">
+            <%= link_to image_tag('sinai-logos/logo-viscodex.png'), @document[:viscodex_ssi], target: '_blank', alt: 'Collation Viewer' %>
+          </div>
+        <% end %>
+        <%= link_to image_tag('iiif-logo.png'), @document[:iiif_manifest_url_ssi], target: '_blank', alt: 'IIIF Manifest' %>
         </div>
       <% end %>
       <div class="si-link-iiif-manifest" data-toggle="tooltip" data-placement="bottom" data-html="true" title="IIIF Manifest">
         <%= link_to image_tag('iiif-logo.png'), @document[:iiif_manifest_url_ssi], target: '_blank', alt: 'IIIF Manifest' %>
       </div>
-    </div>
+    <% end %>
   </div>
 
   <%# ----------- Shelfmark --------------- %>

--- a/app/views/catalog/_show.html.erb
+++ b/app/views/catalog/_show.html.erb
@@ -5,7 +5,7 @@
   <% if cookies[:sinai_authenticated_3day] %>
     <div class='si-link-iiif'>
       <% if @document["viscodex_ssi"] %>
-        <div class='si-link-viscodex' data-toggle="tooltip" data-placement="bottom" data-html="true" title="Click to  viewcollation viewer">
+        <div class='si-link-viscodex' data-toggle="tooltip" data-placement="bottom" data-html="true" title="Click to  view collation viewer">
           <%= link_to image_tag('sinai-logos/logo-viscodex.png'), @document[:viscodex_ssi], target: '_blank', alt: 'Collation Viewer' %>
         </div>
       <% end %>

--- a/app/views/catalog/index.html.erb
+++ b/app/views/catalog/index.html.erb
@@ -1,37 +1,5 @@
-<!-- SINAI -->
-<% if Flipflop.sinai? %>
-<% if !cookies[:sinai_authenticated_3day] %>
-<%
-      cookies[:requested_path] = request.original_url
-      login_service = LoginService.new
-      @token = login_service.create_token
-%>
-<!-- Modal -->
-<div class="modal fade" id="exampleModalCenter" tabindex="-1" role="dialog" aria-labelledby="exampleModalCenterTitle" aria-hidden="true">
-  <div class="modal-dialog modal-dialog-centered" role="document">
-    <div class="modal-content msg-container">
-      <div class="modal-header">
-        <h5 class="modal-title" id="exampleModalLongTitle">Login Required</h5>
-        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-          <span aria-hidden="true">&times;</span>
-        </button>
-        </div>
-      <div class="modal-body">
-      Login is required to view the manuscripts. Please login or register for a free account.
-        <div class="si-auth-modal-btn-block">
-          <div class="si-auth-modal-btn-group">
-            <%= button_to 'Login', ENV['SINAIID_URL'], params: { 'key' => ENV['SINAIID_UCLA_KEY'], callback_url: request.original_url, token: @token }, method: :post, class: 'btn-base btn-outline-sinai--primary' %>
-            <%= link_to 'Register', 'https://sinai-id.org/users/sign_up', class: 'btn-base btn-outline-sinai--primary' %>
-          </div>
-          <button type="button" class="btn-base-link btn-base btn-base-link--sinai" data-dismiss="modal">Skip for Now</button>
-        </div>
-        </div>
-      <div class="modal-footer">
-      </div>
-    </div>
-  </div>
-</div>
-<% end %>
+
+
   <!--% unless has_search_parameters? % -->
   <% if current_page?(root_path) %>
     <%# if there are no input/search related params,
@@ -46,18 +14,3 @@
       <%= render 'search_results' %>
     </div>
   <% end %>
-
-<!-- URSUS -->
-<% else %>
-  <% unless has_search_parameters? %>
-    <%# if there are no input/search related params,
-              display the "home" partial -%>
-    <%= render 'home' %>
-
-  <% else %>
-    <div class='content-container--index-page'>
-      <%= render 'facets' %>
-      <%= render 'search_results' %>
-    </div>
-  <% end %>
-<% end %>

--- a/app/views/catalog/index.html.erb
+++ b/app/views/catalog/index.html.erb
@@ -1,5 +1,3 @@
-
-
   <!--% unless has_search_parameters? % -->
   <% if current_page?(root_path) %>
     <%# if there are no input/search related params,

--- a/app/views/catalog/index_results/_modal.html.erb
+++ b/app/views/catalog/index_results/_modal.html.erb
@@ -1,3 +1,6 @@
+<% doc_presenter = index_presenter(document) %>
+
+
 <%
 cookies[:requested_path] = request.original_url
 login_service = LoginService.new
@@ -20,7 +23,7 @@ Login is required to view the manuscripts. Please login or register for a free a
       <%= button_to 'Login', ENV['SINAIID_URL'], params: { 'key' => ENV['SINAIID_UCLA_KEY'], callback_url: request.original_url, token: @token }, method: :post, class: 'btn-base btn-outline-sinai--primary' %>
       <%= link_to 'Register', 'https://sinai-id.org/users/sign_up', class: 'btn-base btn-outline-sinai--primary' %>
     </div>
-    <%= link_to document['shelfmark_ssi'], document %>
+    <%= link_to 'Continue', document %>
   </div>
   </div>
 <div class="modal-footer">

--- a/app/views/catalog/index_results/_modal.html.erb
+++ b/app/views/catalog/index_results/_modal.html.erb
@@ -1,33 +1,30 @@
 <% doc_presenter = index_presenter(document) %>
 
 <%
-cookies[:requested_path] = request.original_url
-login_service = LoginService.new
-@token = login_service.create_token
+  cookies[:requested_path] = request.original_url
+  login_service = LoginService.new
+  @token = login_service.create_token
 %>
 <!-- Modal -->
 <div class="modal fade" id="exampleModalCenter" tabindex="-1" role="dialog" aria-labelledby="exampleModalCenterTitle" aria-hidden="true">
-<div class="modal-dialog modal-dialog-centered" role="document">
-<div class="modal-content msg-container">
-<div class="modal-header">
-  <h5 class="modal-title" id="exampleModalLongTitle">Login Required</h5>
-  <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-    <span aria-hidden="true">&times;</span>
-  </button>
-  </div>
-<div class="modal-body">
-Login required to view manuscript images. Select "Continue" to view the item record without images.
-  <div class="si-auth-modal-btn-block">
-    <div class="si-auth-modal-btn-group">
-      <%= button_to 'Login', ENV['SINAIID_URL'], params: { 'key' => ENV['SINAIID_UCLA_KEY'], callback_url: request.original_url, token: @token }, method: :post, class: 'btn-base btn-outline-sinai--primary btn-modal' %>
-      <%= link_to 'Register', 'https://sinai-id.org/users/sign_up', class: 'btn-base btn-outline-sinai--primary btn-modal' %>
-      <%= link_to 'Continue', document, class: 'btn-base btn-outline-sinai--primary btn-modal' %>
+  <div class="modal-dialog modal-dialog-centered" role="document">
+    <div class="modal-content msg-container">
+      <div class="modal-header">
+          <h5 class="modal-title" id="exampleModalLongTitle">Login Required</h5>
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </div>
+        <div class="modal-body">
+        Login required to view manuscript images. Select "Continue" to view the item record without images.
+        <div class="si-auth-modal-btn-block">
+          <div class="si-auth-modal-btn-group">
+            <%= button_to 'Login', ENV['SINAIID_URL'], params: { 'key' => ENV['SINAIID_UCLA_KEY'], callback_url: request.original_url, token: @token }, method: :post, class: 'btn-base btn-outline-sinai--primary btn-modal' %>
+            <%= link_to 'Register', 'https://sinai-id.org/users/sign_up', class: 'btn-base btn-outline-sinai--primary btn-modal' %>
+            <%= link_to 'Continue', document, class: 'btn-base btn-outline-sinai--primary btn-modal' %>
+          </div>
+        </div>
+      </div>
     </div>
-
   </div>
-  </div>
-<div class="modal-footer">
-</div>
-</div>
-</div>
 </div>

--- a/app/views/catalog/index_results/_modal.html.erb
+++ b/app/views/catalog/index_results/_modal.html.erb
@@ -17,13 +17,13 @@ login_service = LoginService.new
   </button>
   </div>
 <div class="modal-body">
-Login is required to view the manuscripts. Please login or register for a free account.
+Login required to view manuscript images. Select "Continue" to view the item record without images.
   <div class="si-auth-modal-btn-block">
     <div class="si-auth-modal-btn-group">
       <%= button_to 'Login', ENV['SINAIID_URL'], params: { 'key' => ENV['SINAIID_UCLA_KEY'], callback_url: request.original_url, token: @token }, method: :post, class: 'btn-base btn-outline-sinai--primary' %>
       <%= link_to 'Register', 'https://sinai-id.org/users/sign_up', class: 'btn-base btn-outline-sinai--primary' %>
     </div>
-    <%= link_to 'Continue', document %>
+    <%= link_to 'Continue', document, class: 'btn-base btn-outline-sinai--primary' %>
   </div>
   </div>
 <div class="modal-footer">

--- a/app/views/catalog/index_results/_modal.html.erb
+++ b/app/views/catalog/index_results/_modal.html.erb
@@ -1,6 +1,5 @@
 <% doc_presenter = index_presenter(document) %>
 
-
 <%
 cookies[:requested_path] = request.original_url
 login_service = LoginService.new
@@ -21,8 +20,8 @@ Login required to view manuscript images. Select "Continue" to view the item rec
   <div class="si-auth-modal-btn-block">
     <div class="si-auth-modal-btn-group">
       <%= button_to 'Login', ENV['SINAIID_URL'], params: { 'key' => ENV['SINAIID_UCLA_KEY'], callback_url: request.original_url, token: @token }, method: :post, class: 'btn-base btn-outline-sinai--primary btn-modal' %>
-      <%= button_to 'Register', 'https://sinai-id.org/users/sign_up', class: 'btn-base btn-outline-sinai--primary btn-modal' %>
-      <%= button_to 'Continue', document, class: 'btn-base btn-outline-sinai--primary btn-modal' %>
+      <%= link_to 'Register', 'https://sinai-id.org/users/sign_up', class: 'btn-base btn-outline-sinai--primary btn-modal' %>
+      <%= link_to 'Continue', document, class: 'btn-base btn-outline-sinai--primary btn-modal' %>
     </div>
 
   </div>

--- a/app/views/catalog/index_results/_modal.html.erb
+++ b/app/views/catalog/index_results/_modal.html.erb
@@ -1,0 +1,30 @@
+<%
+cookies[:requested_path] = request.original_url
+login_service = LoginService.new
+@token = login_service.create_token
+%>
+<!-- Modal -->
+<div class="modal fade" id="exampleModalCenter" tabindex="-1" role="dialog" aria-labelledby="exampleModalCenterTitle" aria-hidden="true">
+<div class="modal-dialog modal-dialog-centered" role="document">
+<div class="modal-content msg-container">
+<div class="modal-header">
+  <h5 class="modal-title" id="exampleModalLongTitle">Login Required</h5>
+  <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+    <span aria-hidden="true">&times;</span>
+  </button>
+  </div>
+<div class="modal-body">
+Login is required to view the manuscripts. Please login or register for a free account.
+  <div class="si-auth-modal-btn-block">
+    <div class="si-auth-modal-btn-group">
+      <%= button_to 'Login', ENV['SINAIID_URL'], params: { 'key' => ENV['SINAIID_UCLA_KEY'], callback_url: request.original_url, token: @token }, method: :post, class: 'btn-base btn-outline-sinai--primary' %>
+      <%= link_to 'Register', 'https://sinai-id.org/users/sign_up', class: 'btn-base btn-outline-sinai--primary' %>
+    </div>
+    <%= link_to document['shelfmark_ssi'], document %>
+  </div>
+  </div>
+<div class="modal-footer">
+</div>
+</div>
+</div>
+</div>

--- a/app/views/catalog/index_results/_modal.html.erb
+++ b/app/views/catalog/index_results/_modal.html.erb
@@ -20,10 +20,11 @@ login_service = LoginService.new
 Login required to view manuscript images. Select "Continue" to view the item record without images.
   <div class="si-auth-modal-btn-block">
     <div class="si-auth-modal-btn-group">
-      <%= button_to 'Login', ENV['SINAIID_URL'], params: { 'key' => ENV['SINAIID_UCLA_KEY'], callback_url: request.original_url, token: @token }, method: :post, class: 'btn-base btn-outline-sinai--primary' %>
-      <%= link_to 'Register', 'https://sinai-id.org/users/sign_up', class: 'btn-base btn-outline-sinai--primary' %>
+      <%= button_to 'Login', ENV['SINAIID_URL'], params: { 'key' => ENV['SINAIID_UCLA_KEY'], callback_url: request.original_url, token: @token }, method: :post, class: 'btn-base btn-outline-sinai--primary btn-modal' %>
+      <%= button_to 'Register', 'https://sinai-id.org/users/sign_up', class: 'btn-base btn-outline-sinai--primary btn-modal' %>
+      <%= button_to 'Continue', document, class: 'btn-base btn-outline-sinai--primary btn-modal' %>
     </div>
-    <%= link_to 'Continue', document, class: 'btn-base btn-outline-sinai--primary' %>
+
   </div>
   </div>
 <div class="modal-footer">

--- a/e2e/cypress/integration/sinai_work_show_spec.js
+++ b/e2e/cypress/integration/sinai_work_show_spec.js
@@ -24,4 +24,11 @@ describe('Sinai Work show pages', () => {
     cy.contains('div.tooltip-inner','IIIF Manifest');
     cy.percySnapshot();
   });
+
+  it('Sinai Not Logged In', () => {
+    cy.clearCookie('sinai_authenticated');
+    cy.setCookie('sinai_authenticated', 'false')
+    cy.visit(Cypress.env('SINAI_BASE_URL') + '/catalog/' + encodeURIComponent('ark:/21198/z1s76kq5'));
+    cy.percySnapshot();
+  });
 });

--- a/e2e/cypress/integration/sinai_work_show_spec.js
+++ b/e2e/cypress/integration/sinai_work_show_spec.js
@@ -24,11 +24,4 @@ describe('Sinai Work show pages', () => {
     cy.contains('div.tooltip-inner','IIIF Manifest');
     cy.percySnapshot();
   });
-
-  it('Sinai Not Logged In', () => {
-    cy.clearCookie('sinai_authenticated');
-    cy.setCookie('sinai_authenticated', 'false')
-    cy.visit(Cypress.env('SINAI_BASE_URL') + '/catalog/' + encodeURIComponent('ark:/21198/z1s76kq5'));
-    cy.percySnapshot();
-  });
 });

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -113,8 +113,7 @@ RSpec.describe ApplicationController, type: :controller do
       it 'directs to requested path' do
         controller.sinai_authn_check
         # expect(controller).to have_received(:request)
-        expect(response.status).to eq(200) #not redirected
-        
+        expect(response.status).to eq(200) # not redirected
       end
     end
   end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -110,10 +110,10 @@ RSpec.describe ApplicationController, type: :controller do
         allow(controller).to receive(:sinai_authenticated_3day?).and_return(false)
         allow(controller).to receive(:request).and_return(instance_double('ActionDispatch::Request', path: controller.solr_document_path('ark:')))
       end
-      # it 'redirects to requested path' do
-      #   controller.sinai_authn_check
-      #   expect(controller).to have_received(:redirect_to).with('/redirect_target')
-      # end
+      it 'redirects to requested path' do
+        controller.sinai_authn_check
+        # expect(controller).to have_received(:redirect_to).with('/redirect_target')
+      end
     end
   end
 

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ApplicationController, type: :controller do
 
   before do
     allow(Flipflop).to receive(:sinai?).and_return(true)
-    allow(controller).to receive(:redirect_target).and_return('/redirect_target')
+    # allow(controller).to receive(:redirect_target).and_return('/redirect_target')
     allow(controller).to receive(:cookies).and_return(requested_path: '/requested_path')
     allow(controller).to receive(:login_path).and_return('/test_login')
     allow(controller).to receive(:redirect_to)
@@ -110,9 +110,11 @@ RSpec.describe ApplicationController, type: :controller do
         allow(controller).to receive(:sinai_authenticated_3day?).and_return(false)
         allow(controller).to receive(:request).and_return(instance_double('ActionDispatch::Request', path: controller.solr_document_path('ark:')))
       end
-      it 'redirects to requested path' do
+      it 'directs to requested path' do
         controller.sinai_authn_check
-        # expect(controller).to have_received(:redirect_to).with('/redirect_target')
+        # expect(controller).to have_received(:request)
+        expect(response.status).to eq(200) #not redirected
+        
       end
     end
   end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -110,10 +110,10 @@ RSpec.describe ApplicationController, type: :controller do
         allow(controller).to receive(:sinai_authenticated_3day?).and_return(false)
         allow(controller).to receive(:request).and_return(instance_double('ActionDispatch::Request', path: controller.solr_document_path('ark:')))
       end
-      it 'redirects to requested path' do
-        controller.sinai_authn_check
-        expect(controller).to have_received(:redirect_to).with('/redirect_target')
-      end
+      # it 'redirects to requested path' do
+      #   controller.sinai_authn_check
+      #   expect(controller).to have_received(:redirect_to).with('/redirect_target')
+      # end
     end
   end
 


### PR DESCRIPTION
Connected to [APPS-1197](https://jira.library.ucla.edu/browse/APPS-1197)


Acceptance criteria:
- [x] Text for the info text box that will replace the image viewer (the square brackets denote a button): 
         Login required to view manuscript images.   [Login]  [Register]
- [x] Updated text for the existing index page pop-up when a user selects an item but is not logged in:
         Login required to view manuscript images. Select "Continue" to view the item record without images.
- [x] When not logged in, a user can select a manuscript to view and be directed to the item page for that manuscript
- [x] In this scenario, a user will be able to see all metadata, but no manuscript images and no viscodex icon and iiif manifest icon
- [x] There is some form of message or notification to the user that instructs them to login to view images
- [x] When a user logs in while on an item page, they will return to the page and the images will display in the viewer