### PR TITLE
APPS-1347 - Inconsistent Sinaimanuscripts Auth Behavior

### DIFF
--- a/app/assets/stylesheets/theme_sinai/header/_si-navbar.scss
+++ b/app/assets/stylesheets/theme_sinai/header/_si-navbar.scss
@@ -100,7 +100,7 @@
 // Aligns "Login" link to "About" link
 .site-navbar__item--sinai .button_to {
   position: relative;
-  top: -0.0625rem;
+  top: -0.0125rem;
 }
 
 .site-header__search-icon--sinai {

--- a/app/views/shared/header/_header_navbar.html.erb
+++ b/app/views/shared/header/_header_navbar.html.erb
@@ -19,7 +19,6 @@
           login_service = LoginService.new
           @token = login_service.create_token
           %>
-          <%# cookies[:request_original_url] = request.original_url %>
           <li class='nav-item site-navbar__item--sinai'>
             <%= button_to 'LOGIN', ENV['SINAIID_URL'], params: { 'key' => ENV['SINAIID_UCLA_KEY'], callback_url: request.original_url, token: @token }, method: :post, class: 'btn btn_nav_link--sinai' %>
           </li>

--- a/app/views/shared/header/_header_navbar.html.erb
+++ b/app/views/shared/header/_header_navbar.html.erb
@@ -14,14 +14,14 @@
 
         <li class='nav-item site-navbar__item--sinai'><%= link_to "Search#{image_tag('sinai-logos/search-icon-bold.svg', class: 'site-header__search-icon--sinai', alt: 'Search icon')}".html_safe, '/catalog?utf8=%E2%9C%93&q=&search_field=all_fields' %></li>
         <li class='nav-item site-navbar__item--sinai'><%= link_to 'About', about_path %></li>
-
         <% if !cookies[:sinai_authenticated_3day] %>
-          <% cookies[:request_original_url] = request.original_url %>
-          <li class='nav-item site-navbar__item--sinai'><%#= link_to 'Login', login_path %>
-          <%= button_to 'LOGIN/REGISTER', ENV['SINAIID_URL'], params: { 'key' => ENV['SINAIID_UCLA_KEY'], callback_url: request.original_url, token: @token }, method: :post, class: 'btn btn_nav_link--sinai' %>
+          <li class='nav-item site-navbar__item--sinai'>
+            <% cookies[:request_original_url] = request.original_url %>
+            <a href="#" data-toggle="modal" data-target="#exampleModalCenter">
+              LOGIN/REGISTER
+            </a>
           </li>
         <% end %>
-
       </ul>
     </div>
 

--- a/app/views/shared/header/_header_navbar.html.erb
+++ b/app/views/shared/header/_header_navbar.html.erb
@@ -14,14 +14,37 @@
 
         <li class='nav-item site-navbar__item--sinai'><%= link_to "Search#{image_tag('sinai-logos/search-icon-bold.svg', class: 'site-header__search-icon--sinai', alt: 'Search icon')}".html_safe, '/catalog?utf8=%E2%9C%93&q=&search_field=all_fields' %></li>
         <li class='nav-item site-navbar__item--sinai'><%= link_to 'About', about_path %></li>
+
         <% if !cookies[:sinai_authenticated_3day] %>
-          <li class='nav-item site-navbar__item--sinai'>
-            <% cookies[:request_original_url] = request.original_url %>
-            <a href="#" data-toggle="modal" data-target="#exampleModalCenter">
-              LOGIN/REGISTER
-            </a>
+
+        <%
+        cookies[:requested_path] = request.original_url
+        login_service = LoginService.new
+        @token = login_service.create_token
+        %>
+        <% cookies[:request_original_url] = request.original_url %>
+
+        <%= ENV['SINAIID_URL'] %>
+        <%= request.original_url %>
+        <%= @token %>
+
+
+
+
+
+          <li class='nav-item site-navbar__item--sinai'><%#= link_to 'Login', login_path %>
+                   <%= button_to 'Login', ENV['SINAIID_URL'], params: { 'key' => ENV['SINAIID_UCLA_KEY'], callback_url: request.original_url, token: @token }, method: :post, class: 'btn-base btn-outline-sinai--primary btn-modal' %>
+          <%= button_to 'LOGIN/REGISTER', ENV['SINAIID_URL'], params: { 'key' => ENV['SINAIID_UCLA_KEY'], callback_url: request.original_url, token: @token }, method: :post, class: 'btn btn_nav_link--sinai' %>
           </li>
+          <% if !cookies[:sinai_authenticated_3day] %>
+            <li>
+              <a href='#' data-toggle='modal' data-target='#exampleModalCenter'>
+                LOGIN/REGISTER
+              </a>
+            </li>
+          <% end %>
         <% end %>
+
       </ul>
     </div>
 

--- a/app/views/shared/header/_header_navbar.html.erb
+++ b/app/views/shared/header/_header_navbar.html.erb
@@ -11,18 +11,19 @@
 
     <div class='site-navbar__link-block--sinai'>
       <ul class='nav'>
-
         <li class='nav-item site-navbar__item--sinai'><%= link_to "Search#{image_tag('sinai-logos/search-icon-bold.svg', class: 'site-header__search-icon--sinai', alt: 'Search icon')}".html_safe, '/catalog?utf8=%E2%9C%93&q=&search_field=all_fields' %></li>
         <li class='nav-item site-navbar__item--sinai'><%= link_to 'About', about_path %></li>
-
         <% if !cookies[:sinai_authenticated_3day] %>
-          <% cookies[:request_original_url] = request.original_url %>
-          <% @token = login_service.create_token %>
-          <li class='nav-item site-navbar__item--sinai'><%#= link_to 'Login', login_path %>
-            <%= button_to 'LOGIN/REGISTER', ENV['SINAIID_URL'], params: { 'key' => ENV['SINAIID_UCLA_KEY'], callback_url: request.original_url, token: @token }, method: :post, class: 'btn btn_nav_link--sinai' %>
+          <%
+          cookies[:requested_path] = request.original_url
+          login_service = LoginService.new
+          @token = login_service.create_token
+          %>
+          <%# cookies[:request_original_url] = request.original_url %>
+          <li class='nav-item site-navbar__item--sinai'>
+            <%= button_to 'LOGIN', ENV['SINAIID_URL'], params: { 'key' => ENV['SINAIID_UCLA_KEY'], callback_url: request.original_url, token: @token }, method: :post, class: 'btn btn_nav_link--sinai' %>
           </li>
         <% end %>
-
       </ul>
     </div>
 

--- a/app/views/shared/header/_header_navbar.html.erb
+++ b/app/views/shared/header/_header_navbar.html.erb
@@ -16,33 +16,11 @@
         <li class='nav-item site-navbar__item--sinai'><%= link_to 'About', about_path %></li>
 
         <% if !cookies[:sinai_authenticated_3day] %>
-
-        <%
-        cookies[:requested_path] = request.original_url
-        login_service = LoginService.new
-        @token = login_service.create_token
-        %>
-        <% cookies[:request_original_url] = request.original_url %>
-
-        <%= ENV['SINAIID_URL'] %>
-        <%= request.original_url %>
-        <%= @token %>
-
-
-
-
-
+          <% cookies[:request_original_url] = request.original_url %>
+          <% @token = login_service.create_token %>
           <li class='nav-item site-navbar__item--sinai'><%#= link_to 'Login', login_path %>
-                   <%= button_to 'Login', ENV['SINAIID_URL'], params: { 'key' => ENV['SINAIID_UCLA_KEY'], callback_url: request.original_url, token: @token }, method: :post, class: 'btn-base btn-outline-sinai--primary btn-modal' %>
-          <%= button_to 'LOGIN/REGISTER', ENV['SINAIID_URL'], params: { 'key' => ENV['SINAIID_UCLA_KEY'], callback_url: request.original_url, token: @token }, method: :post, class: 'btn btn_nav_link--sinai' %>
+            <%= button_to 'LOGIN/REGISTER', ENV['SINAIID_URL'], params: { 'key' => ENV['SINAIID_UCLA_KEY'], callback_url: request.original_url, token: @token }, method: :post, class: 'btn btn_nav_link--sinai' %>
           </li>
-          <% if !cookies[:sinai_authenticated_3day] %>
-            <li>
-              <a href='#' data-toggle='modal' data-target='#exampleModalCenter'>
-                LOGIN/REGISTER
-              </a>
-            </li>
-          <% end %>
         <% end %>
 
       </ul>

--- a/default.env
+++ b/default.env
@@ -16,7 +16,7 @@ RAILS_SERVE_STATIC_FILES=true
 RAILS_HOST=localhost
 
 # skip the auth check in development - don't set this in prod!
-###SINAI_ID_BYPASS=false
+SINAI_ID_BYPASS=true
 
 # The solr for the Californica environment that this Ursus environment will use as its data source
 SOLR_URL=http://127.0.0.1:8983/solr/sinai

--- a/default.env
+++ b/default.env
@@ -16,7 +16,7 @@ RAILS_SERVE_STATIC_FILES=true
 RAILS_HOST=localhost
 
 # skip the auth check in development - don't set this in prod!
-SINAI_ID_BYPASS=true
+###SINAI_ID_BYPASS=false
 
 # The solr for the Californica environment that this Ursus environment will use as its data source
 SOLR_URL=http://127.0.0.1:8983/solr/sinai


### PR DESCRIPTION
Connected to [APPS-1347](https://jira.library.ucla.edu/browse/APPS-1347)

Fix Sinai Manuscripts EMEL-based authorization on both the stage and production frontend environment which broke after the recent domain update (see ticket for details).

- [x] The _Login_ kink on the upper-right of the header works as expected
- [x] Clicking on a "padlocked" image pops up the login modal as expected
- [x] The user is able to login and view images using either login method

**Notes**

The two problems were separate and distinct requiring two fixes. The upper-right link problem pre-dated the domain update.

-----

**Changed Files**
app/assets/stylesheets/theme_sinai/header/_si-navbar.scss](https://github.com/UCLALibrary/sinaimanuscripts/compare
app/views/shared/header/_header_navbar.html.erb
```
