### PR TITLE
fix: combine uniform title and descriptive title as one field on the item page Works

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Ursus is a [Blacklight](https://projectblacklight.org/) application and only nee
 Ursus can be locally run in two ways:
 
 1. Running in standalone mode
-1. Running in conjunction with local instance Californica
+1. Running in conjunction with local instance feedMe solr
 
 ---
 
@@ -42,14 +42,13 @@ The file `docker-compose-standalone.yml` includes a setup with a clone of the ur
 
 #### 1. Clone the repo from GitHub
 ```
-:3003
-cd ursus
+:3004
+cd sinaimanuscripts
 ```
 
 #### 3. Set up the databases
 
 ```
-docker-compose run web bundle exec rails db:setup
 docker-compose run sinai bundle exec rails db:setup
 ```
 

--- a/app/presenters/sinai/contents_works_metadata_presenter.rb
+++ b/app/presenters/sinai/contents_works_metadata_presenter.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+module Sinai
+  class ContentsWorksMetadataPresenter
+    attr_reader :document
+
+    def initialize(document:)
+      @document = document
+      @config = YAML.safe_load(File.open(Rails.root.join('config', 'metadata-sinai/contents_works_metadata.yml')))
+    end
+
+    def contents_terms
+      @document.slice(*@config.keys)
+    end
+  end
+end

--- a/app/views/catalog/work_record--sinai/_content_metadata.html.erb
+++ b/app/views/catalog/work_record--sinai/_content_metadata.html.erb
@@ -5,6 +5,7 @@
   <input type="radio" name="tabs" id="tabone" checked="checked">
   <label for="tabone">Content</label>
   <div class="primary-metadata_tab-box--sinai">
+  <%= render 'catalog/work_record--sinai/content_work_metadata', document: document %>
   <% contents.each do |field_name, field| %>
     <div class="metadata-block--sinai">
         <span class="metadata-block_title--sinai"> <%= (render_document_show_field_label document, field: field_name).tr(':', '') %></span>

--- a/app/views/catalog/work_record--sinai/_content_metadata.html.erb
+++ b/app/views/catalog/work_record--sinai/_content_metadata.html.erb
@@ -1,7 +1,8 @@
 <% doc_presenter = show_presenter(document) %>
+<% works = Sinai::ContentsWorksMetadataPresenter.new(document: doc_presenter.fields_to_render).contents_terms %>
 <% contents = Sinai::ContentsMetadataPresenter.new(document: doc_presenter.fields_to_render).contents_terms %>
 
-<% if contents.length > 0 %>
+<% if contents.length > 0 || works.length > 0 %>
   <input type="radio" name="tabs" id="tabone" checked="checked">
   <label for="tabone">Content</label>
   <div class="primary-metadata_tab-box--sinai">

--- a/app/views/catalog/work_record--sinai/_content_work_metadata.html.erb
+++ b/app/views/catalog/work_record--sinai/_content_work_metadata.html.erb
@@ -5,7 +5,7 @@
     <span class="metadata-block_value--sinai">
     <% index = 0 %>
     <% contents.each do |field_name, field| %>
-    <% if index == 0 && field_name.include?("descriptive_title") %>
+    <% if index == 0 && field_name.include?("descriptive_title") && contents.length > 1 %>
         <%= doc_presenter.field_value field %>&nbsp;|&nbsp;
     <% else %>
        <%= doc_presenter.field_value field %>

--- a/app/views/catalog/work_record--sinai/_content_work_metadata.html.erb
+++ b/app/views/catalog/work_record--sinai/_content_work_metadata.html.erb
@@ -1,0 +1,16 @@
+<% doc_presenter = show_presenter(document) %>
+<% contents = Sinai::ContentsWorksMetadataPresenter.new(document: doc_presenter.fields_to_render).contents_terms %>
+<div class="metadata-block--sinai">
+    <span class="metadata-block_title--sinai">Works</span>
+    <span class="metadata-block_value--sinai">
+    <% index = 0 %>
+    <% contents.each do |field_name, field| %>
+    <% if index == 0 && field_name.include?("descriptive_title") %>
+        <%= doc_presenter.field_value field %>&nbsp;|&nbsp;
+    <% else %>
+       <%= doc_presenter.field_value field %>
+    <% end %>
+     <% index += 1 %>
+    <% end %>
+    </span>
+</div>

--- a/config/metadata-sinai/contents_metadata.yml
+++ b/config/metadata-sinai/contents_metadata.yml
@@ -1,8 +1,6 @@
 # These fields are in order of display
 
 # Sinai only - Contents
-descriptive_title_tesim: 'Descriptive title'
-uniform_title_tesim: 'Uniform title'
 alternative_title_tesim: 'Alternative title'
 incipit_tesim: 'Incipit'
 explicit_tesim: 'Explicit'

--- a/config/metadata-sinai/contents_works_metadata.yml
+++ b/config/metadata-sinai/contents_works_metadata.yml
@@ -1,0 +1,2 @@
+descriptive_title_tesim: 'Descriptive title'
+uniform_title_tesim: 'Uniform title'

--- a/spec/presenters/sinai/contents_metadata_presenter_spec.rb
+++ b/spec/presenters/sinai/contents_metadata_presenter_spec.rb
@@ -4,8 +4,6 @@ require 'rails_helper'
 RSpec.describe Sinai::ContentsMetadataPresenter do
   let(:solr_doc) do
     {
-      'descriptive_title_tesim' => 'Descriptive title',
-      'uniform_title_tesim' => 'Uniform title',
       'alternative_title_tesim' => 'Alternative title',
       'incipit_tesim' => 'Incipit',
       'explicit_tesim' => 'Explicit',
@@ -16,8 +14,6 @@ RSpec.describe Sinai::ContentsMetadataPresenter do
   end
   let(:solr_doc_missing_items) do
     {
-      'descriptive_title_tesim' => 'Descriptive title',
-      'uniform_title_tesim' => 'Uniform title',
       'alternative_title_tesim' => 'Alternative title',
       'incipit_tesim' => 'Incipit'
     }
@@ -28,14 +24,6 @@ RSpec.describe Sinai::ContentsMetadataPresenter do
 
   context 'with a solr document containing contents metadata' do
     describe '#terms' do
-      it 'returns the Descriptive title Key' do
-        expect(config['descriptive_title_tesim'].to_s).to eq('Descriptive title')
-      end
-
-      it 'returns the Uniform title Key' do
-        expect(config['uniform_title_tesim'].to_s).to eq('Uniform title')
-      end
-
       it 'returns the Alternative title Key' do
         expect(config['alternative_title_tesim'].to_s).to eq('Alternative title')
       end
@@ -66,7 +54,7 @@ RSpec.describe Sinai::ContentsMetadataPresenter do
       let(:missing) { presenter_object_missing_items.contents_terms.keys.length }
 
       it "returns existing keys" do
-        expect(all).to eq 8
+        expect(all).to eq 6
         expect(config.length).to eq all
       end
 

--- a/spec/presenters/sinai/contents_works_metadata_presenter_spec.rb
+++ b/spec/presenters/sinai/contents_works_metadata_presenter_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Sinai::ContentsWorksMetadataPresenter do
+  let(:solr_doc) do
+    {
+      'descriptive_title_tesim' => 'Descriptive title',
+      'uniform_title_tesim' => 'Uniform title'
+    }
+  end
+  let(:solr_doc_missing_items) do
+    {
+      'descriptive_title_tesim' => 'Descriptive title'
+    }
+  end
+  let(:presenter_object) { described_class.new(document: solr_doc) }
+  let(:presenter_object_missing_items) { described_class.new(document: solr_doc_missing_items) }
+  let(:config) { YAML.safe_load(File.open(Rails.root.join('config', 'metadata-sinai/contents_works_metadata.yml'))) }
+
+  context 'with a solr document containing contents metadata' do
+    describe '#terms' do
+      it 'returns the Descriptive title Key' do
+        expect(config['descriptive_title_tesim'].to_s).to eq('Descriptive title')
+      end
+
+      it 'returns the Uniform title Key' do
+        expect(config['uniform_title_tesim'].to_s).to eq('Uniform title')
+      end
+    end
+
+    describe "#contents_terms terms" do
+      let(:all) { presenter_object.contents_terms.keys.length }
+      let(:missing) { presenter_object_missing_items.contents_terms.keys.length }
+
+      it "returns existing keys" do
+        expect(all).to eq 2
+        expect(config.length).to eq all
+      end
+
+      it "is missing elements" do
+        expect(all - missing).to_not eq 0
+        expect(config.length - missing).to_not eq 0
+      end
+    end
+  end
+end


### PR DESCRIPTION
<img width="816" alt="image" src="https://user-images.githubusercontent.com/4259468/225404600-e3a42479-0714-4fa4-add6-a42faf911208.png">
