### PR TITLE
fix: update Illustrations note label to Decoration note

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -228,7 +228,7 @@ class CatalogController < ApplicationController
     config.add_show_field 'condition_note_tesim', label: 'Condition note', break_options: {}
     config.add_show_field 'collation_tesim', label: 'Collation'
     config.add_show_field 'foliation_tesim', label: 'Foliation'
-    config.add_show_field 'illustrations_note_tesim', label: 'Illustrations note'
+    config.add_show_field 'illustrations_note_tesim', label: 'Decoration note'
 
     config.add_show_field 'hand_note_tesim', limit: 7, label: 'Hand note' # 'Writing and hands'
 

--- a/app/views/catalog/work_record--sinai/_decorations_metadata.html.erb
+++ b/app/views/catalog/work_record--sinai/_decorations_metadata.html.erb
@@ -3,7 +3,7 @@
 
 <% if decorations.length > 0 %>
   <input type="radio" name="tabs" id="tabfour">
-  <label for="tabfour">Decorations</label>
+  <label for="tabfour">Decoration</label>
   <div class="primary-metadata_tab-box--sinai">
   <% decorations.each do |field_name, field| %>
     <div class="metadata-block--sinai">

--- a/config/metadata-sinai/decoration_metadata.yml
+++ b/config/metadata-sinai/decoration_metadata.yml
@@ -1,4 +1,4 @@
 # These fields are in order of display
 
 # Sinai only - Decoration
-illustrations_note_tesim: 'Illustrations note'
+illustrations_note_tesim: 'Decoration note'

--- a/config/metadata/physical_description_metadata.yml
+++ b/config/metadata/physical_description_metadata.yml
@@ -8,7 +8,7 @@ binding_note_ssi: 'Binding note'
 condition_note_ssi: 'Condition note'
 collation_tesim: 'Collation'
 foliation_tesim: 'Foliation'
-illustrations_note_tesim: 'Illustrations note'
+illustrations_note_tesim: 'Decoration note'
 form_tesim: 'Form'
 
 # Sinai only

--- a/spec/presenters/sinai/decoration_metadata_presenter_spec.rb
+++ b/spec/presenters/sinai/decoration_metadata_presenter_spec.rb
@@ -4,12 +4,12 @@ require 'rails_helper'
 RSpec.describe Sinai::DecorationMetadataPresenter do
   let(:solr_doc) do
     {
-      'illustrations_note_tesim' => 'Illustrations note'
+      'illustrations_note_tesim' => 'Decoration note'
     }
   end
   # let(:solr_doc_missing_items) do
   #   {
-  #     'illustrations_note_tesim' => 'Illustrations note'
+  #     'illustrations_note_tesim' => 'Decoration note'
   #   }
   # end
   let(:presenter_object) { described_class.new(document: solr_doc) }
@@ -18,8 +18,8 @@ RSpec.describe Sinai::DecorationMetadataPresenter do
 
   context 'with a solr document containing overview metadata' do
     describe 'config' do
-      it 'returns the Illustrations note' do
-        expect(config['illustrations_note_tesim'].to_s).to eq('Illustrations note')
+      it 'returns the Decoration note' do
+        expect(config['illustrations_note_tesim'].to_s).to eq('Decoration note')
       end
     end
 

--- a/spec/presenters/ursus/physical_description_metadata_presenter_spec.rb
+++ b/spec/presenters/ursus/physical_description_metadata_presenter_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Ursus::PhysicalDescriptionMetadataPresenter do
       'writing_system_tesim' => 'Writing system',
       'script_tesim' => 'Script',
       'hand_note_tesim' => 'Hand note',
-      'illustrations_note_tesim' => 'Illustrations note',
+      'illustrations_note_tesim' => 'Decoration note',
       'condition_note_ssi' => 'Condition note',
       'binding_note_ssi' => 'Binding note',
       'inscription_tesim' => 'Inscription',
@@ -59,8 +59,8 @@ RSpec.describe Ursus::PhysicalDescriptionMetadataPresenter do
         expect(config['format_tesim'].to_s).to eq 'Format'
       end
 
-      it 'returns the Illustrations note Key' do
-        expect(config['illustrations_note_tesim'].to_s).to eq 'Illustrations note'
+      it 'returns the Decoration note Key' do
+        expect(config['illustrations_note_tesim'].to_s).to eq 'Decoration note'
       end
 
       it 'returns the Incription note Key' do


### PR DESCRIPTION
Connected to: [APPS-2289](https://jira.library.ucla.edu/browse/APPS-2289)
Sinai: Update label of "Illustrations Note" to be "Decoration Note"

#### Acceptance Criteria:

-[x] When viewing an item page on Sinai, if there is decoration information, there will be a tab named "Decoration" and a field named "Decoration note".

<img width="650" alt="Screenshot 2023-05-31 at 1 23 21 PM" src="https://github.com/UCLALibrary/sinaimanuscripts/assets/751697/c46096ac-3cd0-49e8-ae99-78cf8dd7319a">
