### PR TITLE
fix: APPS-1799  Sinai: "Place of Origin" should not be a facet

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -106,7 +106,6 @@ class CatalogController < ApplicationController
 
     # SINAI
     config.add_facet_field 'genre_sim', sort: 'index'
-    config.add_facet_field 'place_of_origin_sim', sort: 'index', label: 'Place of origin'
     config.add_facet_field 'year_isim', range: true
     config.add_facet_field 'human_readable_language_sim', sort: 'index'
     config.add_facet_field 'writing_system_sim', sort: 'index', label: 'Writing system'


### PR DESCRIPTION
Connected to: [APPS-1799](https://jira.library.ucla.edu/browse/APPS-1799)