### PR TITLE
feat: Add contents and contents_note to the dropdown title search

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -331,47 +331,34 @@ class CatalogController < ApplicationController
       }
     end
 
-    # URSUS
-    unless Flipflop.sinai?
-      config.add_search_field('title_tesim', label: 'Title') do |field|
-        field.solr_parameters = {
-          qf: 'title_tesim',
-          pf: ''
-        }
-      end
-      config.add_search_field('subject_tesim', label: 'Subject') do |field|
-        field.solr_parameters = {
-          qf: 'subject_tesim',
-          pf: ''
-        }
-      end
-    end
-
-    # SINAI
     config.add_search_field('shelfmark_tsi', label: 'Shelfmark') do |field|
       field.solr_parameters = {
         qf: 'shelfmark_tsi',
         pf: ''
       }
     end
-    config.add_search_field('title_tesim descriptive_title_tesim alternative_title_tesim uniform_title_tesim', label: 'Title') do |field|
+
+    config.add_search_field('title_tesim descriptive_title_tesim contents_ssi contents_note_tesim alternative_title_tesim uniform_title_tesim', label: 'Title') do |field|
       field.solr_parameters = {
-        qf: 'title_tesim descriptive_title_tesim alternative_title_tesim uniform_title_tesim',
+        qf: 'title_tesim descriptive_title_tesim contents_ssi contents_note_tesim alternative_title_tesim uniform_title_tesim',
         pf: ''
       }
     end
+
     config.add_search_field('author_tesim scribe_tesim associated_name_tesim translator_tesim', label: 'Names') do |field|
       field.solr_parameters = {
         qf: 'author_tesim scribe_tesim associated_name_tesim translator_tesim',
         pf: ''
       }
     end
+
     config.add_search_field('incipit_tesim explicit_tesim', label: 'Incipit/Explicit') do |field|
       field.solr_parameters = {
         qf: 'incipit_tesim explicit_tesim',
         pf: ''
       }
     end
+
     config.add_search_field('toc_tesim contents_note_tesim contents_ssi', label: 'Contents') do |field|
       field.solr_parameters = {
         qf: 'toc_tesim contents_note_tesim contents_ssi',

--- a/e2e/cypress/e2e/sinai_search.cy.js
+++ b/e2e/cypress/e2e/sinai_search.cy.js
@@ -40,7 +40,7 @@ describe('Sinai Search', () => {
 
   it('Search Title Found', () => {
     cy.get('[id=q]').type('sinai');
-    cy.get('select').select('Title').should('have.value', 'title_tesim descriptive_title_tesim alternative_title_tesim uniform_title_tesim');
+    cy.get('select').select('Title').should('have.value', 'title_tesim descriptive_title_tesim contents_ssi contents_note_tesim alternative_title_tesim uniform_title_tesim');
     cy.get('[id=search]').click();
     cy.get('.search-count__heading').contains('Catalog Results');
     cy.percySnapshot();


### PR DESCRIPTION
Connected to: [APPS-2332](https://jira.library.ucla.edu/browse/APPS-2332)

- [x] When a user performs a "Title" search, the "Works", "Contents", and "Contents note" fields are all searched.