### PR TITLE
feat: make metadata field text URL aware and br tags within text should work by using html_safe

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem 'mysql2', '~> 0.5'
 gem 'pkg-config', '~> 1.1'
 gem 'puma', '~> 5.5' # app server
 gem 'rails', '~> 5.2'
+gem 'rails_autolink'
 gem 'rollbar' # Error reporting tool
 gem 'rsolr', '>= 1.0'
 gem 'sassc-rails', '>= 2.1.2' # SASS -> CSS compiler
@@ -35,7 +36,6 @@ gem 'sprockets', '>= 3.7.2', '< 4'
 gem 'turbolinks', '~> 5' # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
 gem 'uglifier', '>= 1.3.0' # JavaScript compressor
 gem 'whenever', require: false
-gem 'rails_autolink'
 
 group :development, :test do
   gem 'bixby', '~> 1.0'

--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ gem 'sprockets', '>= 3.7.2', '< 4'
 gem 'turbolinks', '~> 5' # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
 gem 'uglifier', '>= 1.3.0' # JavaScript compressor
 gem 'whenever', require: false
+gem 'rails_autolink'
 
 group :development, :test do
   gem 'bixby', '~> 1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -306,6 +306,10 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
+    rails_autolink (1.1.8)
+      actionview (> 3.1)
+      activesupport (> 3.1)
+      railties (> 3.1)
     railties (5.2.4.5)
       actionpack (= 5.2.4.5)
       activesupport (= 5.2.4.5)
@@ -487,6 +491,7 @@ DEPENDENCIES
   puma (~> 5.5)
   rails (~> 5.2)
   rails-controller-testing (>= 1.0.4)
+  rails_autolink
   rollbar
   rsolr (>= 1.0)
   rspec-collection_matchers

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -207,9 +207,9 @@ class CatalogController < ApplicationController
     config.add_show_field 'description_tesim', label: 'Description'
     config.add_show_field 'caption_tesim', label: 'Caption'
     config.add_show_field 'toc_tesim', label: 'Table of Contents'
-    config.add_show_field 'contents_note_tesim', label: 'Contents note'
+    config.add_show_field 'contents_note_tesim', label: 'Contents note', auto_link: true # make this field url aware
     config.add_show_field 'contents_ssi', label: 'Contents'
-    config.add_show_field 'undertext_objects_ssim', label: 'Undertext Objects', break_options: {}
+    config.add_show_field 'undertext_objects_ssim', label: 'Undertext Objects', auto_link: true, break_options: {}
     config.add_show_field 'provenance_tesim', label: 'Provenance'
     config.add_show_field 'colophon_tesim', label: 'Colophon'
     config.add_show_field 'note_tesim', label: 'Note'
@@ -252,8 +252,8 @@ class CatalogController < ApplicationController
     config.add_show_field 'geographic_coordinates_ssim'
 
     # HISTORY TAB
-    config.add_show_field 'related_tesim', label: 'Related Items', break_options: {}
-    config.add_show_field 'overtext_manuscript_ssm', label: 'Overtext manuscript', break_options: {}
+    config.add_show_field 'related_tesim', label: 'Related Items', break_options: {}, auto_link: true
+    config.add_show_field 'overtext_manuscript_ssm', label: 'Overtext manuscript', break_options: {}, auto_link: true
 
     # SECONDARY
     # Find This Item

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,0 +1,30 @@
+require 'rails_autolink'
+
+module ApplicationHelper
+    include ERB::Util # provides html_escape
+
+    # Uses Rails auto_link to add links to fields
+    #
+    # @param field [String,Hash] string to format and escape, or a hash as per helper_method
+    # @option field [SolrDocument] :document
+    # @option field [String] :field name of the solr field
+    # @option field [Blacklight::Configuration::IndexField, Blacklight::Configuration::ShowField] :config
+    # @option field [Array] :value array of values for the field
+    # @param show_link [Boolean]
+    # @return [ActiveSupport::SafeBuffer]
+    def iconify_auto_link(field, show_link = true)
+      puts field.inspect  
+      byebug
+      if field.is_a? Hash
+          options = field[:config].separator_options || {}
+          text = field[:value].to_sentence(options)
+        else
+          text = field
+        end
+        # this block is only executed when a link is inserted;
+        # if we pass text containing no links, it just returns text.
+        auto_link(html_escape(text)) do |value|
+          "<span class='fa fa-external-link'></span>#{('&nbsp;' + value) if show_link}"
+        end
+    end
+  end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,30 +1,29 @@
+# frozen_string_literal: true
 require 'rails_autolink'
 
 module ApplicationHelper
-    include ERB::Util # provides html_escape
+  include ERB::Util # provides html_escape
 
-    # Uses Rails auto_link to add links to fields
-    #
-    # @param field [String,Hash] string to format and escape, or a hash as per helper_method
-    # @option field [SolrDocument] :document
-    # @option field [String] :field name of the solr field
-    # @option field [Blacklight::Configuration::IndexField, Blacklight::Configuration::ShowField] :config
-    # @option field [Array] :value array of values for the field
-    # @param show_link [Boolean]
-    # @return [ActiveSupport::SafeBuffer]
-    def iconify_auto_link(field, show_link = true)
-      puts field.inspect  
-      byebug
-      if field.is_a? Hash
-          options = field[:config].separator_options || {}
-          text = field[:value].to_sentence(options)
-        else
-          text = field
-        end
-        # this block is only executed when a link is inserted;
-        # if we pass text containing no links, it just returns text.
-        auto_link(html_escape(text)) do |value|
-          "<span class='fa fa-external-link'></span>#{('&nbsp;' + value) if show_link}"
-        end
+  # Uses Rails auto_link to add links to fields
+  #
+  # @param field [String,Hash] string to format and escape, or a hash as per helper_method
+  # @option field [SolrDocument] :document
+  # @option field [String] :field name of the solr field
+  # @option field [Blacklight::Configuration::IndexField, Blacklight::Configuration::ShowField] :config
+  # @option field [Array] :value array of values for the field
+  # @param show_link [Boolean]
+  # @return [ActiveSupport::SafeBuffer]
+  def iconify_auto_link(field, show_link = true)
+    if field.is_a? Hash
+      options = field[:config].separator_options || {}
+      text = field[:value].to_sentence(options)
+    else
+      text = field
+    end
+    # this block is only executed when a link is inserted;
+    # if we pass text containing no links, it just returns text.
+    auto_link(html_escape(text)) do |value|
+      "<span class='fa fa-external-link'></span>#{('&nbsp;' + value) if show_link}"
     end
   end
+end

--- a/app/processors/auto_link.rb
+++ b/app/processors/auto_link.rb
@@ -5,16 +5,13 @@ class AutoLink < Blacklight::Rendering::AbstractStep
 
   def render
     if config.auto_link
-        linkedValues = values.map do |value| 
-            auto_link(html_escape(value)) do |text|
-                "#{text }"
-            end
-        end  
-        next_step(linkedValues)
+      linked_values = values.map do |value|
+        auto_link(html_escape(value), &:to_s)
+      end
+      next_step(linked_values)
     else
-        next_step(values)
+      next_step(values)
     end
-    
   end
 
   def html_escape(*args)

--- a/app/processors/auto_link.rb
+++ b/app/processors/auto_link.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+# Joins values using configured value, linebreak, or delimiter
+class AutoLink < Blacklight::Rendering::AbstractStep
+  include ActionView::Helpers::TextHelper
+
+  def render
+    if config.auto_link
+        linkedValues = values.map do |value| 
+            auto_link(html_escape(value)) do |text|
+                "#{text }"
+            end
+        end  
+        next_step(linkedValues)
+    else
+        next_step(values)
+    end
+    
+  end
+
+  def html_escape(*args)
+    ERB::Util.html_escape(*args)
+  end
+end

--- a/app/processors/custom_join.rb
+++ b/app/processors/custom_join.rb
@@ -8,7 +8,7 @@ class CustomJoin < Blacklight::Rendering::AbstractStep
       next_step(values.map { |x| html_escape(x) })
     else
       joiner = config.break_options ? (config.join_with || '<br>'.html_safe) : (config.join_with || '&nbsp;|&nbsp;'.html_safe)
-      next_step(safe_join(values, joiner))
+      next_step(safe_join(values.map { |x| x.html_safe }, joiner))
     end
   end
 

--- a/app/processors/custom_join.rb
+++ b/app/processors/custom_join.rb
@@ -8,7 +8,7 @@ class CustomJoin < Blacklight::Rendering::AbstractStep
       next_step(values.map { |x| html_escape(x) })
     else
       joiner = config.break_options ? (config.join_with || '<br>'.html_safe) : (config.join_with || '&nbsp;|&nbsp;'.html_safe)
-      next_step(safe_join(values.map { |x| x.html_safe }, joiner))
+      next_step(safe_join(values.map(&:html_safe), joiner))
     end
   end
 

--- a/app/views/catalog/work_record--sinai/_content_metadata.html.erb
+++ b/app/views/catalog/work_record--sinai/_content_metadata.html.erb
@@ -8,21 +8,12 @@
   <div class="primary-metadata_tab-box--sinai">
   <%= render 'catalog/work_record--sinai/content_work_metadata', document: document %>
   <% contents.each do |field_name, field| %>
-   <% if field_name == "undertext_objects_ssim" %>
-    <div class="metadata-block--sinai">
-        <span class="metadata-block_title--sinai">
-          <%= 'Undertext objects' %>
-        </span>
-        <span class="metadata-block_value--sinai">
-         <%= render_undertext_objects_markup %>
-        </span>
-      </div>
-    <% else %>
+   
       <div class="metadata-block--sinai">
           <span class="metadata-block_title--sinai"> <%= (render_document_show_field_label document, field: field_name).tr(':', '') %></span>
           <span class="metadata-block_value--sinai"><%= doc_presenter.field_value field %></span>
       </div>
-    <% end %>
+   
   <% end %>
   </div>
 <% end %>

--- a/app/views/catalog/work_record--sinai/_content_metadata.html.erb
+++ b/app/views/catalog/work_record--sinai/_content_metadata.html.erb
@@ -8,12 +8,10 @@
   <div class="primary-metadata_tab-box--sinai">
   <%= render 'catalog/work_record--sinai/content_work_metadata', document: document %>
   <% contents.each do |field_name, field| %>
-   
       <div class="metadata-block--sinai">
           <span class="metadata-block_title--sinai"> <%= (render_document_show_field_label document, field: field_name).tr(':', '') %></span>
           <span class="metadata-block_value--sinai"><%= doc_presenter.field_value field %></span>
       </div>
-   
   <% end %>
   </div>
 <% end %>

--- a/config/initializers/blacklight.rb
+++ b/config/initializers/blacklight.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 ActiveSupport::Reloader.to_prepare do
-  Blacklight::Rendering::Pipeline.operations = [Blacklight::Rendering::HelperMethod,
+  Blacklight::Rendering::Pipeline.operations = [
+                                                AutoLink,
+                                                Blacklight::Rendering::HelperMethod,
                                                 Blacklight::Rendering::LinkToFacet,
                                                 Blacklight::Rendering::Microdata,
-                                                CustomJoin]
+                                                CustomJoin
+  ]
 end

--- a/config/initializers/blacklight.rb
+++ b/config/initializers/blacklight.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 ActiveSupport::Reloader.to_prepare do
   Blacklight::Rendering::Pipeline.operations = [
-                                                AutoLink,
-                                                Blacklight::Rendering::HelperMethod,
-                                                Blacklight::Rendering::LinkToFacet,
-                                                Blacklight::Rendering::Microdata,
-                                                CustomJoin
+    AutoLink,
+    Blacklight::Rendering::HelperMethod,
+    Blacklight::Rendering::LinkToFacet,
+    Blacklight::Rendering::Microdata,
+    CustomJoin
   ]
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,12 @@
-version: '3.6'
+version: "3.6"
 
 services:
   sinai:
     # image: uclalibrary/sinaimanuscripts:latest
     build: .
-    command: 'sh start-sinai.sh'
+    stdin_open: true
+    tty: true
+    command: "sh start-sinai.sh"
     depends_on:
       - db
       - solr
@@ -12,7 +14,7 @@ services:
       - ./default.env
       - ./docker.env
     ports:
-      - '127.0.0.1:3004:3000'
+      - "127.0.0.1:3004:3000"
     volumes:
       - .:/sinai
       - node_modules:/sinai/node_modules
@@ -25,19 +27,19 @@ services:
       - ./docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
       - mysql_data:/var/lib/mysql
     ports:
-      - '127.0.0.1:3306:3306'
+      - "127.0.0.1:3306:3306"
     environment:
-      MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
+      MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
 
   solr:
     image: uclalibrary/solr-ursus:7.4
     ports:
-      - '127.0.0.1:8983:8983'
+      - "127.0.0.1:8983:8983"
 
   solr_test:
     image: uclalibrary/solr-ursus:7.4
     ports:
-      - '127.0.0.1:8985:8983'
+      - "127.0.0.1:8985:8983"
 
 volumes:
   mysql_data:


### PR DESCRIPTION


https://jira.library.ucla.edu/browse/APPS-2327
https://workshop.projectblacklight.org/v7.11.1/catalog-helper-method-usage/
Acceptance criteria:

[x] The "Undertext Object", "Contents",  "Overtext manuscript", and "Related" fields support html, such as line breaks and hyperlinks, when a CSV with html values in those columns is ingested to Sinai using feed_ursus

https://docs.library.ucla.edu/display/DEV/Make+Sinai+Fields+html+aware