### PR TITLE
feat: APPS-1199 Reset Sinai id token to expire in 1 year

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -37,9 +37,9 @@ class ApplicationController < ActionController::Base
   end
 
   def sinai_authn_check
-    return true if [version_path].include?(request.path) || sinai_authenticated_3day?
+    return true if [version_path].include?(request.path) || sinai_authenticated_1year?
     if ENV['SINAI_ID_BYPASS'] # skip auth in development
-      cookies[:sinai_authenticated_3day] = 'true'
+      cookies[:sinai_authenticated_1year] = 'true'
       return true
     end
     # check_document_paths
@@ -69,6 +69,10 @@ class ApplicationController < ActionController::Base
     cookies[:sinai_authenticated_3day]
   end
 
+  def sinai_authenticated_1year?
+    cookies[:sinai_authenticated_1year]
+  end
+
   def ucla_token?
     # does the request have a querystring containing a param named token and, if so, was it previously written to the database?
     return true if params[:token].present? && SinaiToken.find_by(sinai_token: params[:token])
@@ -83,14 +87,14 @@ class ApplicationController < ActionController::Base
   end
 
   def set_auth_cookies
-    cookies[:sinai_authenticated_3day] = {
+    cookies[:sinai_authenticated_1year] = {
       value: create_encrypted_string.unpack('H*')[0].upcase,
-      expires: Time.zone.now + 3.days,
+      expires: Time.zone.now + 1.year,
       domain: ENV['DOMAIN']
     }
     cookies[:initialization_vector] = {
       value: cipher_iv.unpack('H*')[0].upcase,
-      expires: Time.zone.now + 3.days,
+      expires: Time.zone.now + 1.year,
       domain: ENV['DOMAIN']
     }
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -65,10 +65,6 @@ class ApplicationController < ActionController::Base
     params[:sort] ||= 'score desc' unless params[:q].to_s.empty?
   end
 
-  def sinai_authenticated_3day?
-    cookies[:sinai_authenticated_3day]
-  end
-
   def sinai_authenticated_1year?
     cookies[:sinai_authenticated_1year]
   end

--- a/app/views/catalog/_index.html.erb
+++ b/app/views/catalog/_index.html.erb
@@ -6,7 +6,7 @@
   <%# THUMBNAIL %>
   <% if presenter(document).thumbnail.exists? && tn = presenter(document).thumbnail.thumbnail_tag({}, counter: document_counter_with_offset(document_counter)) %>
     <%# Thumnail NOT logged in %>
-    <% if !cookies[:sinai_authenticated_3day] %>
+    <% if !cookies[:sinai_authenticated_1year] %>
       <div class='document__gallery-thumbnail document__gallery-thumbnail--sinai-generic'>
         <a href='#' data-toggle='modal' data-target='#exampleModalCenter'>
             <%= image_tag('sinai/sinai-generic-thumbnail.png', class: 'document__gallery-thumbnail--sinai-generic') %>
@@ -22,7 +22,7 @@
   <%# ----------------------------------------------- %>
 
   <%# METADATA %>
-  <% if !cookies[:sinai_authenticated_3day] %>
+  <% if !cookies[:sinai_authenticated_1year] %>
     <%# Sinai NOT LOGGED IN %>
     <%# cookies[:request_original_url] = request.original_url %>
 

--- a/app/views/catalog/_index_gallery.html.erb
+++ b/app/views/catalog/_index_gallery.html.erb
@@ -1,7 +1,7 @@
 <% if Flipflop.sinai? %>
   <div class="document document__gallery-item document__gallery-item--sinai">
     <div class="document__gallery-item-wrapper">
-      <% if !cookies[:sinai_authenticated_3day] %>
+      <% if !cookies[:sinai_authenticated_1year] %>
         <a href="#" class="document__gallery-item-thumbnail-link--sinai" data-toggle="modal" data-target="#exampleModalCenter">
           <%= image_tag("sinai/sinai-generic-thumbnail.png") %>
         </a>

--- a/app/views/catalog/_media_viewer.html.erb
+++ b/app/views/catalog/_media_viewer.html.erb
@@ -1,6 +1,6 @@
 <% if can?(:read, document) %>
 <%# --------- Sinai Not Logged in ----- %>
-  <% if !cookies[:sinai_authenticated_3day] %>
+  <% if !cookies[:sinai_authenticated_1year] %>
     <%
       cookies[:requested_path] = request.original_url
       login_service = LoginService.new

--- a/app/views/catalog/_show.html.erb
+++ b/app/views/catalog/_show.html.erb
@@ -3,7 +3,7 @@
   <%= link_back_to_catalog label: '← Back to Search Results', class: 'si-link si-link-search-results left' %>
   <%= link_to "Terms of Use and Permissions", "/terms-of-use", class: "si-link si-link-terms-of-use center" %>
   <%# ---------- IIIF & Tooltip ------------ %>
-  <% if cookies[:sinai_authenticated_3day] %>
+  <% if cookies[:sinai_authenticated_1year] %>
     <div class='si-link-iiif right'>
       <% if @document["viscodex_ssi"] %>
         <div class='si-link-viscodex' data-toggle="tooltip" data-placement="bottom" data-html="true" title="Click to  view collation viewer">

--- a/app/views/shared/header/_header_navbar.html.erb
+++ b/app/views/shared/header/_header_navbar.html.erb
@@ -13,7 +13,7 @@
       <ul class='nav'>
         <li class='nav-item site-navbar__item--sinai'><%= link_to "Search#{image_tag('sinai-logos/search-icon-bold.svg', class: 'site-header__search-icon--sinai', alt: 'Search icon')}".html_safe, '/catalog?utf8=%E2%9C%93&q=&search_field=all_fields' %></li>
         <li class='nav-item site-navbar__item--sinai'><%= link_to 'About', about_path %></li>
-        <% if !cookies[:sinai_authenticated_3day] %>
+        <% if !cookies[:sinai_authenticated_1year] %>
           <%
           cookies[:requested_path] = request.original_url
           login_service = LoginService.new

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe ApplicationController, type: :controller do
     allow(controller).to receive(:redirect_to)
     allow(controller).to receive(:request).and_return(instance_double('ActionDispatch::Request', path: '/'))
     allow(controller).to receive(:set_auth_cookies)
-    allow(controller).to receive(:sinai_authenticated_3day?).and_return(false)
+    allow(controller).to receive(:sinai_authenticated_1year?).and_return(false)
     allow(controller).to receive(:version_path).and_return('/test_version')
     allow(controller).to receive(:solr_document_path).with('ark:').and_return('/catalog/ark:')
     allow(controller).to receive(:params).and_return(id: nil)
@@ -97,7 +97,7 @@ RSpec.describe ApplicationController, type: :controller do
 
     context 'if we are already authenticated' do
       before do
-        allow(controller).to receive(:sinai_authenticated_3day?).and_return(true)
+        allow(controller).to receive(:sinai_authenticated_1year?).and_return(true)
       end
       it 'allows Rails to continue' do
         expect(controller.sinai_authn_check).to be true
@@ -107,7 +107,7 @@ RSpec.describe ApplicationController, type: :controller do
     context 'if the requested path is solr_document_path' do
       before do
         allow(controller).to receive(:params).and_return(id: 'ark:')
-        allow(controller).to receive(:sinai_authenticated_3day?).and_return(false)
+        allow(controller).to receive(:sinai_authenticated_1year?).and_return(false)
         allow(controller).to receive(:request).and_return(instance_double('ActionDispatch::Request', path: controller.solr_document_path('ark:')))
       end
       it 'directs to requested path' do
@@ -178,7 +178,7 @@ RSpec.describe ApplicationController, type: :controller do
   end # describe ucla_token?
 
   describe 'set_auth_cookies' do
-    context 'creates the sinai_authenticated_3day cookie' do
+    context 'creates the sinai_authenticated_1year cookie' do
       let(:cookies) { {} }
       before do
         allow(controller).to receive(:cookies).and_return(cookies)
@@ -190,14 +190,14 @@ RSpec.describe ApplicationController, type: :controller do
         allow(controller).to receive(:cipher_iv).and_return('mock_cipher_iv')
       end
 
-      it 'sets the sinai_authenticated_3day cookie value' do
+      it 'sets the sinai_authenticated_1year cookie value' do
         controller.set_auth_cookies
-        expect(cookies[:sinai_authenticated_3day][:value]).to eq('mock_encrypted_string'.unpack('H*')[0].upcase)
+        expect(cookies[:sinai_authenticated_1year][:value]).to eq('mock_encrypted_string'.unpack('H*')[0].upcase)
       end
 
-      it 'sets an expiration date for the sinai_authenticated_3day cookie' do
+      it 'sets an expiration date for the sinai_authenticated_1year cookie' do
         controller.set_auth_cookies
-        expect(cookies[:sinai_authenticated_3day][:expires]).to be_kind_of(Time)
+        expect(cookies[:sinai_authenticated_1year][:expires]).to be_kind_of(Time)
       end
 
       it 'sets the initialization_vector cookie value' do


### PR DESCRIPTION
Connected to [APPS-1199](https://uclalibrary.atlassian.net/jira/software/c/projects/APPS/boards/12?selectedIssue=APPS-1199)

The login token for Sinai was reset to expire after 3 days. This was a mistake and we would like the login prompt interval to be 1 year.  John R. indicated that we should be able to make the change on our end without coordinating with EMEL.

[APPS-1199]: https://uclalibrary.atlassian.net/browse/APPS-1199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ