### PR TITLE
fix: APP-2424 Add shelfmark to schema

### DIFF
--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -457,7 +457,6 @@
     <fieldtype name="geohash" class="solr.GeoHashField"/>
  </types>
 
-
  <fields>
    <!-- Valid attributes for fields:
      name: mandatory - the name for the field
@@ -513,9 +512,9 @@
    <!-- format is used for facet, display, and choosing which partial to use for the show view, so it must be stored and indexed -->
    <field name="format" type="string" indexed="true" stored="true"/>
 
-  <field name="title_alpha_numeric_ssort" type="alphaNumericSort" indexed="true" stored="false" multiValued="false"/>
-  
+  <field name="shelfmark_alpha_numeric_ssort" type="alphaNumericSort" indexed="true" stored="true" multiValued="false"/>
 
+  <field name="title_alpha_numeric_ssort" type="alphaNumericSort" indexed="true" stored="false" multiValued="false"/>
 
    <!-- Dynamic field definitions.  If a field name is not found, dynamicFields
         will be used if the name matches any of the patterns.
@@ -602,10 +601,10 @@
    <copyField source="subject_t" dest="subject_unstem_search"/>
    <copyField source="subject_addl_t" dest="subject_addl_unstem_search"/>
    <copyField source="subject_topic_facet" dest="subject_topic_unstem_search"/>
+   <copyField source="shelfmark_ssi" dest="shelfmark_alpha_numeric_ssort" />
 
    <!-- sort fields -->
    <copyField source="pub_date" dest="pub_date_sort"/>
-
 
    <!-- spellcheck fields -->
    <!-- default spell check;  should match fields for default request handler -->
@@ -666,6 +665,5 @@
    <str name="paramkey">param value</str>
  </similarity>
  -->
-
 
 </schema>


### PR DESCRIPTION
Connected to [APPS-2424](https://uclalibrary.atlassian.net/jira/software/c/projects/APPS/boards/12?selectedIssue=APPS-2424)

For `shelfmark` sorting needs add a copyfield which was also missing in the schema.xml

<copyField source="shelfmark_ssi" dest="shelfmark_alpha_numeric_ssort" />

[APPS-2424]: https://uclalibrary.atlassian.net/browse/APPS-2424?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ