### PR TITLE
fix: shelfmark search

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,15 @@
 FROM ruby:2.6
 
-RUN gem install bundler
-
-RUN apt-get update -qq
-# Add https support to apt to download yarn & newer node
-RUN apt-get install -y  apt-transport-https
-
-# Add yarn repo and install along with other rails deps
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 RUN apt-get update -qq
 RUN apt-get install mariadb-client build-essential libpq-dev yarn nodejs chromium-driver libatk-bridge2.0-0 libgtk-3.0 -y
 
 WORKDIR /ursus
 
-# Install Ruby Gems
-ENV BUNDLE_PATH /usr/local/bundle
 COPY Gemfile ./Gemfile
 COPY Gemfile.lock ./Gemfile.lock
 RUN bundle install
 
-# node stuff is currently dev only
-# # Install node packages
-# COPY ./package.json ./package.json
-# COPY ./yarn.lock ./yarn.lock
-# RUN yarn install --frozen-lockfile
-
-# Add sinaimanuscripts site
 # COPY / /sinai
-CMD ["sh", "./start-sinai.sh"]
+CMD ["bundle", "exec", "rails", "s", "-b", "0.0.0.0"]
 
 EXPOSE 3000

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -331,9 +331,9 @@ class CatalogController < ApplicationController
       }
     end
 
-    config.add_search_field('shelfmark_tsi', label: 'Shelfmark') do |field|
+    config.add_search_field('shelfmark_ssi', label: 'Shelfmark') do |field|
       field.solr_parameters = {
-        qf: 'shelfmark_tsi',
+        qf: 'shelfmark_ssi',
         pf: ''
       }
     end

--- a/e2e/cypress/e2e/sinai_search.cy.js
+++ b/e2e/cypress/e2e/sinai_search.cy.js
@@ -32,7 +32,7 @@ describe('Sinai Search', () => {
 
   it('Search Shelfmark Found', () => {
     cy.get('[id=q]').type('sinai syriac 100');
-    cy.get('select').select('Shelfmark').should('have.value', 'shelfmark_tsi');
+    cy.get('select').select('Shelfmark').should('have.value', 'shelfmark_ssi');
     cy.get('[id=search]').click();
     cy.get('.search-count__heading').contains('Catalog Results');
     cy.percySnapshot();

--- a/spec/helpers/blacklight_helper_spec.rb
+++ b/spec/helpers/blacklight_helper_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe BlacklightHelper, type: :helper do
     context 'cc 4.0 license' do
       let(:document) do
         SolrDocument.new(
-          'title_tsim' => "A Fake Document",
+          'title_tesim' => "A Fake Document",
           'id' => '8',
           'license_tesim' => ["http://creativecommons.org/licenses/by/4.0/"]
         )
@@ -24,7 +24,7 @@ RSpec.describe BlacklightHelper, type: :helper do
     context 'no license' do
       let(:document) do
         SolrDocument.new(
-          'title_tsim' => "A Fake Document",
+          'title_tesim' => "A Fake Document",
           'id' => '8'
         )
       end
@@ -35,7 +35,7 @@ RSpec.describe BlacklightHelper, type: :helper do
     context 'a different value' do
       let(:document) do
         SolrDocument.new(
-          'title_tsim' => "A Fake Document",
+          'title_tesim' => "A Fake Document",
           'id' => '8',
           'license_tesim' => ["some other value"]
         )
@@ -55,7 +55,7 @@ RSpec.describe BlacklightHelper, type: :helper do
     context 'has links in solr document' do
       let(:document) do
         SolrDocument.new(
-          'title_tsim' => "A Fake Document",
+          'title_tesim' => "A Fake Document",
           'id' => '8',
           'overtext_manuscript_ssm' => ["http://www.google.com", "http://www.bk.org"]
         )
@@ -71,7 +71,7 @@ RSpec.describe BlacklightHelper, type: :helper do
     context 'has html in solr document' do
       let(:document) do
         SolrDocument.new(
-          'title_tsim' => "A Fake Document",
+          'title_tesim' => "A Fake Document",
           'id' => '8',
           'undertext_objects_ssim' => [
             "<a href=“https://sinaimanuscripts.library.ucla.edu/catalog/ark:%2F21198%2Fz12r59fj”>Months of the Zodiac</a> (Arabic, 10th c. CE), Folios: 119v",


### PR DESCRIPTION
Search by shelfmark wasn't working, due to a typo that had the field type as "_tsi" instead of "_ssi". Investigating this, I also found and fixed a test that used "title_tsim" instead of "title_tesim"